### PR TITLE
CEL-275 Create violation if 'dispatcher.any' file is not found

### DIFF
--- a/app/src/main/java/com/adobe/aem/dot/app/service/ConfigurationOptimizerService.java
+++ b/app/src/main/java/com/adobe/aem/dot/app/service/ConfigurationOptimizerService.java
@@ -115,14 +115,19 @@ public class ConfigurationOptimizerService {
 
     logger.trace("Begin DispatcherConfigService");
 
+    List<Violation> violationCollector = new ArrayList<>();
     DispatcherConfigurationFactory factory = new DispatcherConfigurationFactory();
     ConfigurationParseResults<DispatcherConfiguration> results = factory.parseConfiguration(this.repoURL, this.anyDir);
-    List<Violation> violationCollector = new ArrayList<>(results.getViolations(this.verbosity));
+    if (results != null) {
+      violationCollector.addAll(results.getViolations(this.verbosity));
 
-    // Analyze the dispatcher configuration for violations
-    DispatcherConfiguration dispatcherConfiguration = results.getConfiguration();
-    if (dispatcherConfiguration != null) {
-      violationCollector.addAll(this.dispatcherAnalyzer.getViolations(dispatcherConfiguration, this.verbosity));
+      // Analyze the dispatcher configuration for violations
+      DispatcherConfiguration dispatcherConfiguration = results.getConfiguration();
+      if (dispatcherConfiguration != null) {
+        violationCollector.addAll(this.dispatcherAnalyzer.getViolations(dispatcherConfiguration, this.verbosity));
+      } else {
+        logger.warn("Dispatcher configuration failed to parse correctly.");  // Probably already logged as error.
+      }
     }
 
     // Analyze the Apache Httpd configuration for violations

--- a/core/src/main/java/com/adobe/aem/dot/common/parser/ConfigurationViolations.java
+++ b/core/src/main/java/com/adobe/aem/dot/common/parser/ConfigurationViolations.java
@@ -26,7 +26,6 @@ import lombok.Getter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -52,6 +51,7 @@ public class ConfigurationViolations {
           {"DOTRules:Disp-S4---brace-unclosed", "Unclosed brace encountered."},
           {"DOTRules:Disp-S5---mandatory-missing", " is missing mandatory "},
           {"DOTRules:Disp-S6---property-deprecated", " is deprecated."},
+          {"DOTRules:Disp-S7---no-dispatcher-config", "Could not find Dispatcher configuration file."},
           {"DOTRules:Httpd-S1---include-failed", "Include directive must include existing files."}
   }).collect(Collectors.toMap(data -> data[0], data -> data[1]));
 

--- a/core/src/main/java/com/adobe/aem/dot/dispatcher/core/DispatcherConfigurationFactory.java
+++ b/core/src/main/java/com/adobe/aem/dot/dispatcher/core/DispatcherConfigurationFactory.java
@@ -19,7 +19,10 @@ package com.adobe.aem.dot.dispatcher.core;
 import com.adobe.aem.dot.common.ConfigurationException;
 import com.adobe.aem.dot.common.ConfigurationFileFinder;
 import com.adobe.aem.dot.common.ConfigurationLine;
+import com.adobe.aem.dot.common.ConfigurationSource;
+import com.adobe.aem.dot.common.analyzer.Severity;
 import com.adobe.aem.dot.common.parser.ConfigurationParseResults;
+import com.adobe.aem.dot.common.parser.ConfigurationViolations;
 import com.adobe.aem.dot.dispatcher.core.model.DispatcherConfiguration;
 import com.adobe.aem.dot.dispatcher.core.parser.ConfigurationParser;
 import com.adobe.aem.dot.dispatcher.core.parser.ConfigurationSyntaxException;
@@ -81,9 +84,9 @@ public class DispatcherConfigurationFactory {
 
       // Config file was not found.
       if (dispatcherAnyFile == null) {
-        throw new ConfigurationException(
-                MessageFormat.format("Could not find \"{0}\" configuration file in \"{1}\"",
-                        DispatcherConstants.DISPATCHER_ANY, repoPath));
+        ConfigurationViolations.addViolation("Could not find Dispatcher configuration file.", Severity.MINOR,
+                new ConfigurationSource(repoPath, 0));
+        return new ConfigurationParseResults<>(null, ConfigurationViolations.getViolations());
       }
     }
 

--- a/core/src/test/java/com/adobe/aem/dot/common/analyzer/MultiConfigTests/MultiConfigHelper.java
+++ b/core/src/test/java/com/adobe/aem/dot/common/analyzer/MultiConfigTests/MultiConfigHelper.java
@@ -49,17 +49,17 @@ public class MultiConfigHelper {
 
   // Find good identifiers from the (variable) path
   public static String getConfigurationDirectoryId(String relativeConfPath) {
-    // This is not a foolproof way to get an unique Id, but it served the purpose for the configs that were tested.
-    String pathInfo = PathUtil.stripLastPathElement(relativeConfPath);
-    String folderId = getLastPathElement(pathInfo, true);
-    pathInfo = PathUtil.stripLastPathElement(pathInfo);
-    folderId = getLastPathElement(pathInfo, false) + folderId;  // Last 2 directories in config path.
-    String[] pathParts = PathUtil.split(pathInfo);
-    if (pathParts[pathParts.length - 2].equals("configurations")) {
-      folderId = PathUtil.getLastPathElement(folderId);
+    String directoryId = "unknown";
+    String[] pathParts = PathUtil.split(relativeConfPath);
+    int i;
+    for (i = 0; i < pathParts.length - 2; i++) {
+      if (pathParts[i].equals("configurations")) {
+        directoryId = pathParts[i+2];
+        break;
+      }
     }
 
-    return folderId.indexOf(File.separatorChar) >= 0 ? PathUtil.stripLastPathElement(folderId) : folderId;
+    return directoryId;
   }
 
   /**

--- a/core/src/test/java/com/adobe/aem/dot/common/util/GoUrlUtilTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/common/util/GoUrlUtilTest.java
@@ -49,7 +49,8 @@ public class GoUrlUtilTest {
           { "DOTRules:Disp-S3---quote-unmatched", "https://www.adobe.com/go/aem_cmcq_disp-s3---quote-unma_en" },
           { "DOTRules:Disp-S2---token-unexpected", "https://www.adobe.com/go/aem_cmcq_disp-s2---token-unex_en" },
           { "DOTRules:Disp-S1---brace-missing", "https://www.adobe.com/go/aem_cmcq_disp-s1---brace-miss_en" },
-          { "DOTRules:Disp-S5---mandatory-missing", "https://www.adobe.com/go/aem_cmcq_disp-s5---mandatory-_en" }
+          { "DOTRules:Disp-S5---mandatory-missing", "https://www.adobe.com/go/aem_cmcq_disp-s5---mandatory-_en" },
+          { "DOTRules:Disp-S7---no-dispatcher-config", "https://www.adobe.com/go/aem_cmcq_disp-s7---no-dispatc_en" }
   }).collect(Collectors.toMap(data -> data[0], data -> data[1]));
 
   @Test

--- a/plugin/src/main/java/com/adobe/aem/dot/dispatcher/plugin/AnalyzerMojo.java
+++ b/plugin/src/main/java/com/adobe/aem/dot/dispatcher/plugin/AnalyzerMojo.java
@@ -125,8 +125,8 @@ public class AnalyzerMojo extends AbstractMojo {
       getLog().debug("[Dispatcher Optimizer] Parsing dispatcher config...");
 
       DispatcherConfigurationFactory dispatcherFactory = new DispatcherConfigurationFactory();
-      ConfigurationParseResults<DispatcherConfiguration> dispatcherResults = dispatcherFactory.parseConfiguration(this.dispatcherModuleDir,
-              this.dispatcherConfigPath);
+      ConfigurationParseResults<DispatcherConfiguration> dispatcherResults = dispatcherFactory.parseConfiguration(
+              this.dispatcherModuleDir, this.dispatcherConfigPath);
       DispatcherConfiguration dispatcherConfiguration = dispatcherResults.getConfiguration();
 
       // Collect the violations from the Dispatcher parsing/reading (i.e. not from rule violations)
@@ -149,8 +149,10 @@ public class AnalyzerMojo extends AbstractMojo {
       AnalyzerRuleList list = AnalyzerRuleListFactory.getAnalyzerRuleList(rulesFolder);
 
       // Analyze the dispatcher configuration against the loaded rules.
-      DispatcherAnalyzer dispatcherAnalyzer = new DispatcherAnalyzer(list);
-      violationCollector.addAll(dispatcherAnalyzer.getViolations(dispatcherConfiguration, violationVerbosity));
+      if (dispatcherConfiguration != null) {
+        DispatcherAnalyzer dispatcherAnalyzer = new DispatcherAnalyzer(list);
+        violationCollector.addAll(dispatcherAnalyzer.getViolations(dispatcherConfiguration, violationVerbosity));
+      }
 
       // Analyze the Httpd configuration against the loaded rules, if it loaded.
       if (httpdConfiguration != null) {


### PR DESCRIPTION
## Description

If the 'dispatcher.any' file could not be found (missing, renamed, etc.), issue a violation to let the user know.  This prevents the user from assuming their dispatcher configuration has no violations.

## Related Issue
CEL-275

## Motivation and Context

See Description.

## How Has This Been Tested?

-  Unit tests in core
- Core code was changed to force this situation, and apps & plugin was tested and results were validated.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
