### PR TITLE
CEL-288 - Correct Javadoc generation errors and warnings

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,7 +13,7 @@
   <version>1.0.5-SNAPSHOT</version>
 
   <properties>
-    <maven.javadoc.skip>true</maven.javadoc.skip>
+    <maven.javadoc.skip>false</maven.javadoc.skip>
     <release.tag.name.format>core-v@{project.version}</release.tag.name.format>
   </properties>
 

--- a/core/src/main/java/com/adobe/aem/dot/common/analyzer/rules/AnalyzerRuleListFactory.java
+++ b/core/src/main/java/com/adobe/aem/dot/common/analyzer/rules/AnalyzerRuleListFactory.java
@@ -23,9 +23,12 @@ import java.io.InputStream;
  * Represents a list of analyzer rules.
  */
 public class AnalyzerRuleListFactory {
+  private AnalyzerRuleListFactory() {}
+
   /**
-   * Get the list of default Analyzer Rules
+   * Get the list of default Analyzer Rules.
    * @throws IOException Can throw exception if reading files present a problem.
+   * @return an AnalyzerRuleList instance containing only the core rules
    */
   public static AnalyzerRuleList getAnalyzerRuleList() throws IOException {
     JSONRuleReader jsonRuleReader = new JSONRuleReader();
@@ -35,7 +38,8 @@ public class AnalyzerRuleListFactory {
   /**
    * Get the list of default Analyzer Rules combined with any additional rules defined in the `rulesDirectory`.
    * @param rulesDirectory A folder with addition rules to read.
-   * @throws IOException Can throw exception if reading files present a problem.
+   * @throws IOException Can throw exception if reading files presents a problem.
+   * @return an AnalyzerRuleList instance containing both core rules and additional rules from `rulesDirectory`
    */
   public static AnalyzerRuleList getAnalyzerRuleList(final String rulesDirectory) throws IOException {
     JSONRuleReader jsonRuleReader = new JSONRuleReader();
@@ -46,6 +50,7 @@ public class AnalyzerRuleListFactory {
    * Get the list of default Analyzer Rules combined with any additional rules defined in the provided InputStream.
    * @param externalRules An input stream with additional rules to read.
    * @throws IOException if IO issues are encountered.
+   * @return an AnalyzerRuleList instance containing both core rules and additional rules from the provided InputStream
    */
   public static AnalyzerRuleList getAnalyzerRuleListFromInputStream(final InputStream externalRules) throws IOException {
     JSONRuleReader jsonRuleReader = new JSONRuleReader();

--- a/core/src/main/java/com/adobe/aem/dot/dispatcher/core/analyzer/conditions/IntGreaterOrEqualCheck.java
+++ b/core/src/main/java/com/adobe/aem/dot/dispatcher/core/analyzer/conditions/IntGreaterOrEqualCheck.java
@@ -29,7 +29,7 @@ public class IntGreaterOrEqualCheck extends IntCheck {
   }
 
   /**
-   * Compare to see if the config value is >= the check value.
+   * Compare to see if the config value is &gt;= the check value.
    * @param configValue the value from the dispatcher configuration
    * @param checkValue the value from the optimizer <code>Check</code>
    * @return true if the configuration value is considered valid, false otherwise

--- a/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/ConfigurationValue.java
+++ b/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/ConfigurationValue.java
@@ -27,7 +27,7 @@ import static com.adobe.aem.dot.dispatcher.core.model.ConfigurationValueDefaults
 /**
  * The <code>ConfigurationValue</code> class encapsulates a value from the Configuration.  It stores any type
  * of value along with the filename and the line number from where the value was extracted.
- * @param <E>
+ * @param <E> type of the configuration value to store
  */
 @Getter
 @Setter(AccessLevel.PRIVATE)

--- a/core/src/main/java/com/adobe/aem/dot/dispatcher/core/parser/ConfigurationParser.java
+++ b/core/src/main/java/com/adobe/aem/dot/dispatcher/core/parser/ConfigurationParser.java
@@ -38,7 +38,8 @@ public class ConfigurationParser {
   /**
    * Parse the provided configurationString into a DispatcherConfiguration object.
    * @param configurationLines - a list of <code>ConfigurationLine</code> objects.
-   * @return A <code>DispatcherConfiguration</code> object, as parsed from the provided String.
+   * @return A <code>DispatcherConfiguration</code> object, as parsed from the provided String
+   * @throws ConfigurationSyntaxException when issues parsing the configuration are encountered
    */
   public ConfigurationParseResults<DispatcherConfiguration> parseConfiguration(
           List<ConfigurationLine> configurationLines) throws ConfigurationSyntaxException {

--- a/core/src/main/java/com/adobe/aem/dot/httpd/core/model/DirectorySection.java
+++ b/core/src/main/java/com/adobe/aem/dot/httpd/core/model/DirectorySection.java
@@ -21,7 +21,7 @@ import com.adobe.aem.dot.common.ConfigurationSource;
 import java.util.List;
 
 /**
- * Represents <Directory> and <DirectoryMatch> sections.
+ * Represents &lt;Directory&gt; and &lt;DirectoryMatch&gt; sections.
  * For additional detail on these sections: http://httpd.apache.org/docs/2.4/configuring.html
  */
 public class DirectorySection extends Section {

--- a/core/src/main/java/com/adobe/aem/dot/httpd/core/model/FilesSection.java
+++ b/core/src/main/java/com/adobe/aem/dot/httpd/core/model/FilesSection.java
@@ -21,7 +21,7 @@ import com.adobe.aem.dot.common.ConfigurationSource;
 import java.util.List;
 
 /**
- * Represents <Files> and <FilesMatch> sections.
+ * Represents &lt;Files&gt; and &lt;FilesMatch&gt; sections.
  * For additional detail on these sections: http://httpd.apache.org/docs/2.4/configuring.html
  */
 public class FilesSection extends Section {

--- a/core/src/main/java/com/adobe/aem/dot/httpd/core/model/LocationSection.java
+++ b/core/src/main/java/com/adobe/aem/dot/httpd/core/model/LocationSection.java
@@ -21,7 +21,7 @@ import com.adobe.aem.dot.common.ConfigurationSource;
 import java.util.List;
 
 /**
- * Represents <Location> and <LocationMatch> sections.
+ * Represents &lt;Location&gt; and &lt;LocationMatch&gt; sections.
  * For additional detail on these sections: http://httpd.apache.org/docs/2.4/configuring.html
  */
 public class LocationSection extends Section {

--- a/core/src/main/java/com/adobe/aem/dot/httpd/core/model/VirtualHost.java
+++ b/core/src/main/java/com/adobe/aem/dot/httpd/core/model/VirtualHost.java
@@ -21,7 +21,7 @@ import com.adobe.aem.dot.common.ConfigurationSource;
 import java.util.List;
 
 /**
- * Represents a <VirtualHost> section.
+ * Represents a &lt;VirtualHost&gt; section.
  * For additional detail: http://httpd.apache.org/docs/2.4/configuring.html
  */
 public class VirtualHost extends Section {

--- a/core/src/main/java/com/adobe/aem/dot/httpd/core/parser/HttpdConfigurationParser.java
+++ b/core/src/main/java/com/adobe/aem/dot/httpd/core/parser/HttpdConfigurationParser.java
@@ -88,6 +88,7 @@ public class HttpdConfigurationParser {
    * single ConfigurationLine item. For multiline items, the sourceLineNumber will point to the first line.
    * @param configFile The file to read and parse the configuration data from. Usually httpd.conf or a file it includes
    * @param basePath The path of the "top" configuration, usually the current working directory of httpd.conf
+   * @param optional If set to true, a violation will not be raised if this file cannot be found
    * @return a list of ConfigurationLine items in the order that they were read.
    * @throws IOException when there is an issue reading from a file.
    * @throws FileNotFoundException when configuration file is not found, or is a directory.

--- a/core/src/main/java/com/adobe/aem/dot/httpd/core/parser/HttpdConfigurationScanner.java
+++ b/core/src/main/java/com/adobe/aem/dot/httpd/core/parser/HttpdConfigurationScanner.java
@@ -29,8 +29,8 @@ public class HttpdConfigurationScanner extends ConfigurationScanner {
 
   /**
    * Httpd config files have different rules for what constitutes the end of a token (whitespace only).
-   * @param character
-   * @return
+   * @param character the character to test
+   * @return true, if and only if the provided character is whitespace or the beginning of the next token
    */
   @Override
   protected boolean isWhitespaceOrBeginningOfNextToken(char character) {

--- a/core/src/test/java/com/adobe/aem/dot/common/analyzer/rules/AnalyzerRuleListTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/common/analyzer/rules/AnalyzerRuleListTest.java
@@ -105,8 +105,6 @@ public class AnalyzerRuleListTest {
 
   @Test
   public void shouldReadInternalRules() {
-    AnalyzerRuleListFactory factory = new AnalyzerRuleListFactory();
-    assertNotNull(factory);
     assertTrue("Should have at least 9 core rules available", testRuleList.getEnabledRules().size() >= 9);
     List<Check> checks = testRuleList.getEnabledRules().get(0).getChecks();
     assertTrue("First rules should have 1 check available", checks.size() > 0);

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -28,6 +28,7 @@
     <maven.compiler.target>1.7</maven.compiler.target>
     <maven.version>3.3.9</maven.version>
     <release.tag.name.format>plugin-v@{project.version}</release.tag.name.format>
+    <maven.javadoc.skip>false</maven.javadoc.skip>
   </properties>
 
   <prerequisites>


### PR DESCRIPTION

## Description

In order to release to Maven central we need to provide Javadocs. This PR resolves issues with the generation of Javadocs.


## Related Issue

CEL-288

## Motivation and Context

Unblocking CEL-179 - Release the Dispatcher Optimizer Maven plugin to Maven Central

## How Has This Been Tested?

Existing tests run and updated (`AnalyzerRuleListTest`).

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
