### PR TITLE
CEL-273 - Enable HTTPD parsing related violations to be reported by the plugin

### DIFF
--- a/core/src/main/java/com/adobe/aem/dot/dispatcher/core/DispatcherConfigurationFactory.java
+++ b/core/src/main/java/com/adobe/aem/dot/dispatcher/core/DispatcherConfigurationFactory.java
@@ -84,7 +84,7 @@ public class DispatcherConfigurationFactory {
 
       // Config file was not found.
       if (dispatcherAnyFile == null) {
-        ConfigurationViolations.addViolation("Could not find Dispatcher configuration file.", Severity.MINOR,
+        ConfigurationViolations.addViolation("Could not find Dispatcher configuration file.", Severity.MAJOR,
                 new ConfigurationSource(repoPath, 0));
         return new ConfigurationParseResults<>(null, ConfigurationViolations.getViolations());
       }

--- a/core/src/main/java/com/adobe/aem/dot/httpd/core/parser/HttpdConfigurationParser.java
+++ b/core/src/main/java/com/adobe/aem/dot/httpd/core/parser/HttpdConfigurationParser.java
@@ -131,7 +131,7 @@ public class HttpdConfigurationParser {
                 FeedbackProcessor.error(logger,
                         "Include directive must include existing files.  Check path, or use IncludeOptional.",
                         "", new ConfigurationSource(relativeFilePath, readResult.getLineNumber()),
-                        toInclude.contains("${") ? null : Severity.MINOR);   // Not a violation if path has EnvVar.
+                        toInclude.contains("${") ? null : Severity.MAJOR);   // Not a violation if path has EnvVar.
               } else {
                 configurationLines.addAll(includeConfigurationFiles(includedFiles, configurationLines.size(),
                         includeType, basePath, configFile, currentLineNumber));
@@ -393,7 +393,7 @@ public class HttpdConfigurationParser {
           FeedbackProcessor.error(logger,
                   "Include directive must include existing files.  Check path, or use IncludeOptional.",
                   "", new ConfigurationSource(configFile.getPath(), currentLineNumber),
-                  includeFile.getPath().contains("${") ? null : Severity.MINOR);   // Not a violation if path has EnvVar.
+                  includeFile.getPath().contains("${") ? null : Severity.MAJOR);   // Not a violation if path has EnvVar.
         }
       }
     }

--- a/core/src/test/java/com/adobe/aem/dot/httpd/core/parser/HttpdConfigurationParserTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/httpd/core/parser/HttpdConfigurationParserTest.java
@@ -236,7 +236,7 @@ public class HttpdConfigurationParserTest {
       Violation violation = ConfigurationViolations.getViolations().get(0);
       assertNotNull(violation);
       assertTrue(violation.getContext().startsWith(errMsg));
-      assertEquals(Severity.MINOR, violation.getAnalyzerRule().getSeverity());
+      assertEquals(Severity.MAJOR, violation.getAnalyzerRule().getSeverity());
     }
   }
 

--- a/plugin/src/main/java/com/adobe/aem/dot/dispatcher/plugin/AnalyzerMojo.java
+++ b/plugin/src/main/java/com/adobe/aem/dot/dispatcher/plugin/AnalyzerMojo.java
@@ -157,6 +157,9 @@ public class AnalyzerMojo extends AbstractMojo {
       // Analyze the Httpd configuration against the loaded rules, if it loaded.
       if (httpdConfiguration != null) {
         HttpdAnalyzer httpdAnalyzer = new HttpdAnalyzer(list);
+        // Collect the violations from the Httpd config parsing/reading (i.e. not from rule violations)
+        violationCollector.addAll(httpdResults.getViolations(violationVerbosity));
+        // Collect the Httpd rule violations
         violationCollector.addAll(httpdAnalyzer.getViolations(httpdConfiguration, violationVerbosity));
       }
 


### PR DESCRIPTION


## Description

Enable HTTPD parsing related violations to be reported by the plugin. Bump those errors to MAJOR severity.

## Related Issue

CEL-273

## Motivation and Context

It was discovered that issues detected during HTTPD parsing by the plugin were not being reported.

## How Has This Been Tested?

Existing tests pass. Further plugin ITs should be added.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
