### PR TITLE
CEL-292 Windows issue: Unexpected internal error near index 1

### DIFF
--- a/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/Farm.java
+++ b/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/Farm.java
@@ -19,6 +19,7 @@ package com.adobe.aem.dot.dispatcher.core.model;
 import com.adobe.aem.dot.common.ConfigurationSource;
 import com.adobe.aem.dot.common.analyzer.Severity;
 import com.adobe.aem.dot.common.util.FeedbackProcessor;
+import com.adobe.aem.dot.common.util.PathUtil;
 import com.adobe.aem.dot.dispatcher.core.parser.ConfigurationReader;
 import com.adobe.aem.dot.dispatcher.core.parser.ConfigurationSyntaxException;
 import lombok.AccessLevel;
@@ -94,7 +95,7 @@ public class Farm extends LabeledConfigurationValue {
     // can inspect this filename via the getLabelData() accessor.
     boolean filenameContainsAuthor = false;
     if (this.getLabelData() != null && this.getLabelData().getFileName() != null) {
-      String[] pathParts = this.getLabelData().getFileName().split(File.separator);
+      String[] pathParts = PathUtil.split(this.getLabelData().getFileName());
       String fileName = pathParts[pathParts.length - 1];
       filenameContainsAuthor = fileName.toUpperCase().contains(AUTHOR);
       if (filenameContainsAuthor) {

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,9 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <version>2.9.1</version>
+            <configuration>
+              <source>8</source>
+            </configuration>
             <executions>
               <execution>
                 <id>attach-javadocs</id>


### PR DESCRIPTION
##JIRA##
https://jira.corp.adobe.com/browse/CEL-292

## Description
When splitting a path, the Windows character created an invalid regex string.

## How Has This Been Tested?

Fixed many tests.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
