### PR TITLE
CEL-293 - Match /content* with Suffix and Selector deny rule checks

### DIFF
--- a/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/Filter.java
+++ b/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/Filter.java
@@ -143,6 +143,7 @@ public class Filter extends LabeledConfigurationValue {
             .append(getUrl(), filter.getUrl())
             .append(getExtension(), filter.getExtension())
             .append(getSelectors(), filter.getSelectors())
+            .append(getSuffix(), filter.getSuffix())
             .append(getPath(), filter.getPath())
             .append(getMethod(), filter.getMethod())
             .append(getQuery(), filter.getQuery())

--- a/core/src/main/resources/core-rules.json
+++ b/core/src/main/resources/core-rules.json
@@ -144,7 +144,7 @@
           "condition": "FILTER_LIST_INCLUDES",
           "filterValue": {
             "type": "DENY",
-            "url": "/content/*",
+            "url": "/content*",
             "suffix": "*"
           }
         }
@@ -164,7 +164,7 @@
           "condition": "FILTER_LIST_INCLUDES",
           "filterValue": {
             "type": "DENY",
-            "url": "/content/*",
+            "url": "/content*",
             "selectors": "*"
           }
         }

--- a/core/src/test/java/com/adobe/aem/dot/dispatcher/core/model/FilterTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/dispatcher/core/model/FilterTest.java
@@ -194,4 +194,19 @@ public class FilterTest {
     assertTrue(logsList.get(0).getMessage().startsWith("Each /filter block must begin with a '{' character."));
     assertEquals("Severity should be ERROR.", Level.ERROR, logsList.get(0).getLevel());
   }
+
+  @Test
+  public void filterSelectorSuffixDifferenceNotEqual() {
+    Filter selectorFilter = new Filter();
+    selectorFilter.setType("DENY");
+    selectorFilter.setURL("/content*");
+    selectorFilter.setSelectors("*");
+
+    Filter suffixFilter = new Filter();
+    suffixFilter.setType("DENY");
+    suffixFilter.setURL("/content*");
+    suffixFilter.setSuffix("*");
+
+    assertNotEquals("Filters using selector & suffix properties should not be considered equal", selectorFilter, suffixFilter);
+  }
 }

--- a/core/src/test/resources/com/adobe/aem/dot/common/analyzer/AnalyzerTest/dispatcher.any
+++ b/core/src/test/resources/com/adobe/aem/dot/common/analyzer/AnalyzerTest/dispatcher.any
@@ -45,7 +45,7 @@
     /filter {
         /0001 { /type "deny" /url "*" }
         /0002 { /type "allow" /extension '(css|eot|gif|ico|jpeg|jpg|js|gif|pdf|png|svg|swf|ttf|woff|woff2|html)' /path "/content/dispatchertester" }
-        /0003 { /type "deny" /url "/content/*" /suffix "*" }
+        /0003 { /type "deny" /url "/content*" /suffix "*" }
       }
 
     /cache {

--- a/core/src/test/resources/rule-lists/gold/core_aa_bb.json
+++ b/core/src/test/resources/rule-lists/gold/core_aa_bb.json
@@ -135,7 +135,7 @@
       "condition" : "FILTER_LIST_INCLUDES",
       "filterValue" : {
         "type" : "DENY",
-        "url" : "/content/*",
+        "url" : "/content*",
         "suffix" : "*"
       },
       "failIf" : false
@@ -154,7 +154,7 @@
       "condition" : "FILTER_LIST_INCLUDES",
       "filterValue" : {
         "type" : "DENY",
-        "url" : "/content/*",
+        "url" : "/content*",
         "selectors" : "*"
       },
       "failIf" : false

--- a/test-projects/test-project-all-rules-pass/dispatcher/src/conf.dispatcher.d/filters/skylab_publish_filters.any
+++ b/test-projects/test-project-all-rules-pass/dispatcher/src/conf.dispatcher.d/filters/skylab_publish_filters.any
@@ -37,7 +37,7 @@
 /0021 { /type "deny" /url "/content/regent.html"}
 
 # Deny all suffixes
-/0101 { /type "deny"  /url "/content/*" /suffix "*"  }
+/0101 { /type "deny"  /url "/content*" /suffix "*"  }
 
 # Deny all selectors
-/0102 { /type "deny"  /url "/content/*" /selectors "*"  }
+/0102 { /type "deny"  /url "/content*" /selectors "*"  }


### PR DESCRIPTION


## Description

"Up level" the Sling Selector and Suffix deny rules to match /content*.

Also: Consider the Filter's suffix property when comparing Filters for equality.

## Related Issue

CEL-293

## Motivation and Context

Updating the Suffix and Selector deny rule URL pattern from /content/* to /content* will enable the dispatcher to block requests like /content.badselector.html and /content.html/bad/suffux.html.

## How Has This Been Tested?

Added a new test to cover this issue, and updated the existing tests.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
