### PR TITLE
CEL-295 DOT Plug-in throws a NPE if no httpd.conf is found

### DIFF
--- a/plugin/src/main/java/com/adobe/aem/dot/dispatcher/plugin/AnalyzerMojo.java
+++ b/plugin/src/main/java/com/adobe/aem/dot/dispatcher/plugin/AnalyzerMojo.java
@@ -132,17 +132,22 @@ public class AnalyzerMojo extends AbstractMojo {
       // Collect the violations from the Dispatcher parsing/reading (i.e. not from rule violations)
       List<Violation> violationCollector = dispatcherResults.getViolations(violationVerbosity);
 
-      getLog().debug("[Dispatcher Optimizer] Finished parsing dispatcher config!  Violations: " +
+      getLog().debug("[Dispatcher Optimizer] Finished parsing dispatcher config.  Violations: " +
                              violationCollector.size());
 
       getLog().debug("[Dispatcher Optimizer] Parsing Apache Httpd config...");
 
+      HttpdConfiguration httpdConfiguration = null;
       HttpdConfigurationFactory httpdConfigurationFactory = new HttpdConfigurationFactory();
       ConfigurationParseResults<HttpdConfiguration> httpdResults = httpdConfigurationFactory.getHttpdConfiguration(this.dispatcherModuleDir,
               this.apacheHttpdConfigPath);
-      HttpdConfiguration httpdConfiguration = httpdResults.getConfiguration();
+      if (httpdResults != null) {
+        httpdConfiguration = httpdResults.getConfiguration();
 
-      getLog().debug("[Dispatcher Optimizer] Finished parsing Apache Httpd config!");
+        getLog().debug("[Dispatcher Optimizer] Finished parsing Apache Httpd config.");
+      } else {
+        getLog().debug("[Dispatcher Optimizer] Failed to parse the Apache Httpd config.");
+      }
 
       getLog().debug("[Dispatcher Optimizer] Analyzing Dispatcher and Apache Httpd configurations for violations...");
 


### PR DESCRIPTION
## Description

If not httpd.conf file was found, an allowable condition, the mvn plug-in threw a NPE.

## Motivation and Context

Bug

## How Has This Been Tested?

Modified scenario in plug-it and ensured condition was handled properly.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
