### PR TITLE
CEL-300 - Reduce volume of log content when log level is DEBUG

### DIFF
--- a/core/src/main/java/com/adobe/aem/dot/common/analyzer/AnalyzerRule.java
+++ b/core/src/main/java/com/adobe/aem/dot/common/analyzer/AnalyzerRule.java
@@ -104,7 +104,7 @@ public class AnalyzerRule {
           fieldNameToCheck = elementTokens[2];
           objectToCheck = callGetter(farm, secondLevelElementName);
           configValueToCheck = callGetter(objectToCheck, fieldNameToCheck);
-          logger.debug("Property on object=\"{}\" named=\"{}\" has value=\"{}\"", secondLevelElementName,
+          logger.trace("Property on object=\"{}\" named=\"{}\" has value=\"{}\"", secondLevelElementName,
                   fieldNameToCheck, configValueToCheck);
         } else {
           // This method does not know how to handle this particular rule element
@@ -115,7 +115,7 @@ public class AnalyzerRule {
         logger.trace("secondLevelElement: filter");
 
         configValueToCheck = callGetter(farm, secondLevelElementName);
-        logger.debug("Property on object=\"{}\" named=\"{}\" has value=\"{}\"", topLevelElementName,
+        logger.trace("Property on object=\"{}\" named=\"{}\" has value=\"{}\"", topLevelElementName,
                 secondLevelElementName, configValueToCheck);
         break;
       default:
@@ -191,7 +191,7 @@ public class AnalyzerRule {
               "get" + Character.toUpperCase(fieldName.charAt(0)) + fieldName.substring(1),
               null);
       Object result = propertyDescriptor.getReadMethod().invoke(valueObj);
-      logger.debug("callGetter found result for property=\"{}\" value=\"{}\"", fieldName,
+      logger.trace("callGetter found result for property=\"{}\" value=\"{}\"", fieldName,
               result != null ? result.toString() : "null");
       return result;
     } catch (IntrospectionException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {


### PR DESCRIPTION


## Description

Move some extra-chatty logs to TRACE.

## Related Issue

CEL-300

## Motivation and Context

These logs can cause the log output to become unwieldy. If needed, they can be viewed by running with the log level set to TRACE.

## How Has This Been Tested?

Logs have been generated with the largest known config we have access to, and the total size was decreased dramatically at the DEBUG log level.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
