### PR TITLE
CEL-299 Empty object in rules file causes NPE

### DIFF
--- a/core/src/main/java/com/adobe/aem/dot/common/analyzer/rules/AnalyzerRuleList.java
+++ b/core/src/main/java/com/adobe/aem/dot/common/analyzer/rules/AnalyzerRuleList.java
@@ -51,6 +51,11 @@ public class AnalyzerRuleList {
    * @param origin A short indicator of the origin of the next rules for logging clarity.  Usually file name.
    */
   void addRules(AnalyzerRuleList ruleList, String origin) {
+    if (ruleList == null || ruleList.getRules() == null) {
+      logger.warn("Rule file did not contain any rules.  origin={}", origin);
+      return;
+    }
+
     if (this.rules == null || ruleList.getMergeMode() == MergeMode.REPLACE) {
       this.rules = ruleList.getRules();
       mergeMode = ruleList.getMergeMode();
@@ -190,4 +195,3 @@ public class AnalyzerRuleList {
     return asJson;
   }
 }
-

--- a/core/src/main/java/com/adobe/aem/dot/common/analyzer/rules/JSONRuleReader.java
+++ b/core/src/main/java/com/adobe/aem/dot/common/analyzer/rules/JSONRuleReader.java
@@ -106,7 +106,15 @@ public class JSONRuleReader {
 
   private AnalyzerRuleList parseRulesFromInputStream(InputStream input) throws IOException {
     ObjectMapper objectMapper = new ObjectMapper();
-    return objectMapper.readValue(input, AnalyzerRuleList.class);
+    // Check for empty file.
+    if (input != null && input.available() > 0) {
+      try {
+        return objectMapper.readValue(input, AnalyzerRuleList.class);
+      } catch (IOException ioEx) {
+        logger.warn("Error reading rule file.  Reason=\"{}\"", ioEx.getLocalizedMessage(), ioEx);
+      }
+    }
+    return new AnalyzerRuleList();
   }
 
   /**


### PR DESCRIPTION
## Description

An empty rule file, or an empty object, in the rule file caused an NPE to be thrown.

## Motivation and Context

NPE's should not be thrown.  Scenario is now logged and handled properly.

## How Has This Been Tested?

Manually, setting up the edge-case.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
