### PR TITLE
CEL-301 Support Httpd Include directives which point to a directory

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>com.adobe.aem.dot</groupId>
       <artifactId>dispatcher-optimizer-core</artifactId>
-      <version>1.0.15-SNAPSHOT</version>
+      <version>1.0.17-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/core/src/main/java/com/adobe/aem/dot/common/FileResolver.java
+++ b/core/src/main/java/com/adobe/aem/dot/common/FileResolver.java
@@ -40,11 +40,12 @@ import java.util.regex.Pattern;
  */
 public class FileResolver {
 
-  private String basePath;
+  private final String basePath;
+  private final boolean allowDirectoryPath;
 
   private static final Logger logger = LoggerFactory.getLogger(FileResolver.class);
 
-  private static Map<String, String> cachedIncludeFiles = new HashMap<>();
+  private final static Map<String, String> cachedIncludeFiles = new HashMap<>();
 
   private static final String missingEnvVarStart = "_ENV___";
   private static final String missingEnvVarEnd = "__";
@@ -52,9 +53,11 @@ public class FileResolver {
   /**
    * Instantiate a new FileResolver.
    * @param basePath - the starting point to handle relative path includes from
+   * @param allowDirectoryPath - whether to allow a directory to be included, without wildcards
    */
-  public FileResolver(String basePath) {
+  public FileResolver(String basePath, boolean allowDirectoryPath) {
     this.basePath = basePath;
+    this.allowDirectoryPath = allowDirectoryPath;
   }
 
   /**
@@ -113,7 +116,21 @@ public class FileResolver {
       File[] files = directory.listFiles(fileFilter);
 
       if (files != null && files.length > 0) {
-        return Arrays.asList(files);
+        List<File> directoryFiles = new ArrayList<>();
+        for (File nextFile: files) {
+          String name = PathUtil.stripOffDrive(nextFile.getPath());
+          if (name.startsWith(currentWorkingDirectory)) {
+            name = name.substring(currentWorkingDirectory.length() + 1);
+          } else {
+            String target = PathUtil.stripLastPathElement(filePath);
+            name = PathUtil.appendPaths(target, nextFile.getName());
+          }
+          List<File> nextFiles = resolveFiles(name, currentWorkingDirectory);
+          if (!nextFiles.isEmpty()) {
+            directoryFiles.addAll(nextFiles);
+          }
+        }
+        return directoryFiles;
       } else {
         logger.info("No files included with wildcard include. Path=\"{}\"", resolvedPath);
         return Collections.emptyList();
@@ -154,9 +171,20 @@ public class FileResolver {
     } else {
       File resolvedFile = new File(resolvedPath);
       if (resolvedFile.exists()) {
+        if (resolvedFile.isDirectory()) {
+          if (!allowDirectoryPath) {
+            logger.error("Cannot include a directory.  Use wildcards to include the contents.  Path=\"{}\"", resolvedPath);
+            return Collections.emptyList();
+          }
+
+          logger.warn("Including a directory is not recommended.  Instead, use wildcards.  Path=\"{}\"", resolvedPath);
+          return resolveFiles(PathUtil.appendPaths(filePath, "*"), currentWorkingDirectory);
+        }
+
+        // It is a existing, non-directory file.
         return Collections.singletonList(resolvedFile);
       } else {
-        return new ArrayList<>();
+        return Collections.emptyList();
       }
     }
   }
@@ -278,7 +306,6 @@ public class FileResolver {
 
     // See if the baseIncludePath can fit on any section of the cwd.
     String cwdSection = cwd;
-    //String[] includeSections = PathUtil.split(withoutRelativeParent);
     while (StringUtils.isNotEmpty(cwdSection)) {
       String lastBase = cwdSection;
       // If not absolute path, take away folders from the end.
@@ -323,7 +350,7 @@ public class FileResolver {
       return null;
     }
 
-    cachedIncludeFiles.put(key, combinedPath + includeSuffix);
+    cachedIncludeFiles.put(key, FilenameUtils.separatorsToSystem(combinedPath + includeSuffix));
     return cachedIncludeFiles.get(key);
   }
 }

--- a/core/src/main/java/com/adobe/aem/dot/common/FileResolver.java
+++ b/core/src/main/java/com/adobe/aem/dot/common/FileResolver.java
@@ -116,6 +116,11 @@ public class FileResolver {
       File[] files = directory.listFiles(fileFilter);
 
       if (files != null && files.length > 0) {
+        // If directories are not allowed, then simply return our list instead of processing subdirectories.
+        if (!allowDirectoryPath) {
+          return Arrays.asList(files);
+        }
+
         List<File> directoryFiles = new ArrayList<>();
         for (File nextFile: files) {
           String name = PathUtil.stripOffDrive(nextFile.getPath());

--- a/core/src/main/java/com/adobe/aem/dot/common/FileResolver.java
+++ b/core/src/main/java/com/adobe/aem/dot/common/FileResolver.java
@@ -123,7 +123,7 @@ public class FileResolver {
 
         List<File> directoryFiles = new ArrayList<>();
         for (File nextFile: files) {
-          String name = PathUtil.stripOffDrive(nextFile.getPath());
+          String name = PathUtil.removeDriveLetterPrefix(nextFile.getPath());
           if (name.startsWith(currentWorkingDirectory)) {
             name = name.substring(currentWorkingDirectory.length() + 1);
           } else {

--- a/core/src/main/java/com/adobe/aem/dot/common/util/PathUtil.java
+++ b/core/src/main/java/com/adobe/aem/dot/common/util/PathUtil.java
@@ -85,14 +85,17 @@ public class PathUtil {
   }
 
   /**
-   * For a Windows' path, strip off the drive (ie "C:") from the path.
+   * For a Windows' path, strip off the drive (ie "C:") from the path.  Assumes only one colon in the path, which is
+   * part of the drive (i.e. "C:\...")
    * @param path A path
    * @return path Path without drive.
    */
   public static String stripOffDrive(String path) {
-    if (StringUtils.isNotEmpty(path) && path.length() > 2 && path.charAt(1) == ':') {
-      path = path.substring(2);
+    if (StringUtils.isNotEmpty(path) && path.contains(":")) {
+      String[] split = path.split(":");
+      path = split[1];
     }
+
     return path;
   }
 

--- a/core/src/main/java/com/adobe/aem/dot/common/util/PathUtil.java
+++ b/core/src/main/java/com/adobe/aem/dot/common/util/PathUtil.java
@@ -85,15 +85,24 @@ public class PathUtil {
   }
 
   /**
+   * For a Windows' path, strip off the drive (ie "C:") from the path.
+   * @param path A path
+   * @return path Path without drive.
+   */
+  public static String stripOffDrive(String path) {
+    if (StringUtils.isNotEmpty(path) && path.length() > 2 && path.charAt(1) == ':') {
+      path = path.substring(2);
+    }
+    return path;
+  }
+
+  /**
    * Return the final folder or filename.
    * @param path A path
    * @return path Path without the final folder. If not a path (no slashes), returns original string.
    */
   public static String getLastPathElement(String path) {
-    if (path.contains(":")) {
-      String[] split = path.split(":");
-      path = split[1];
-    }
+    path = stripOffDrive(path);
     return Paths.get(path).getFileName().toString();
   }
 

--- a/core/src/main/java/com/adobe/aem/dot/common/util/PathUtil.java
+++ b/core/src/main/java/com/adobe/aem/dot/common/util/PathUtil.java
@@ -90,7 +90,7 @@ public class PathUtil {
    * @param path A path
    * @return path Path without drive.
    */
-  public static String stripOffDrive(String path) {
+  public static String removeDriveLetterPrefix(String path) {
     if (StringUtils.isNotEmpty(path) && path.contains(":")) {
       String[] split = path.split(":");
       path = split[1];
@@ -100,12 +100,12 @@ public class PathUtil {
   }
 
   /**
-   * Return the final folder or filename.
+   * Return the name of the final folder or filename.
    * @param path A path
    * @return path Path without the final folder. If not a path (no slashes), returns original string.
    */
   public static String getLastPathElement(String path) {
-    path = stripOffDrive(path);
+    path = removeDriveLetterPrefix(path);
     return Paths.get(path).getFileName().toString();
   }
 

--- a/core/src/main/java/com/adobe/aem/dot/dispatcher/core/resolver/IncludeResolver.java
+++ b/core/src/main/java/com/adobe/aem/dot/dispatcher/core/resolver/IncludeResolver.java
@@ -97,7 +97,7 @@ public class IncludeResolver {
 
         String includeFolder = PathUtil.stripLastPathElement(includeFile);
         String fileToInclude = getFilePathFromInclude(line, includeFile);
-        FileResolver fileResolver = new FileResolver(this.basePath);
+        FileResolver fileResolver = new FileResolver(this.basePath, false);
         List<File> filesToInclude = fileResolver.resolveFiles(fileToInclude, includeFolder);
 
         for (File file : filesToInclude) {

--- a/core/src/main/java/com/adobe/aem/dot/httpd/core/parser/HttpdConfigurationParser.java
+++ b/core/src/main/java/com/adobe/aem/dot/httpd/core/parser/HttpdConfigurationParser.java
@@ -234,7 +234,7 @@ public class HttpdConfigurationParser {
   }
 
   private List<File> getFilesToInclude(String pattern, String basePath) {
-    FileResolver fileResolver = new FileResolver(basePath);
+    FileResolver fileResolver = new FileResolver(basePath, true);
     return fileResolver.resolveFiles(pattern);
   }
 

--- a/core/src/test/java/com/adobe/aem/dot/common/analyzer/FileResolverTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/common/analyzer/FileResolverTest.java
@@ -115,8 +115,6 @@ public class FileResolverTest {
     assertTrue("files should NOT have some files", files.isEmpty());
 
     List<ILoggingEvent> logsList = listAppender.list;
-    // Check that the 'unclosed' regex was logged - "regex(.*" - should be the first entry in the logs.
-    assertTrue(logsList.get(0).getMessage().startsWith("Cannot include a directory.  Use wildcards to include the contents.  Path="));
     assertTrue(logsList.get(0).getMessage().startsWith("Cannot include a directory.  Use wildcards to include the contents.  Path="));
     assertEquals("Severity should be WARN.", Level.ERROR, logsList.get(0).getLevel());
   }

--- a/core/src/test/java/com/adobe/aem/dot/common/analyzer/FileResolverTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/common/analyzer/FileResolverTest.java
@@ -43,7 +43,7 @@ public class FileResolverTest {
 
   @Before
   public void before() {
-    fileResolver = new FileResolver(missingBasePath);
+    fileResolver = new FileResolver(missingBasePath, false);
 
     classPath = PathEncodingHelper.getDecodedClassPath(this.getClass());
     realPath = PathUtil.stripFirstPathElement(classPath).substring(1);
@@ -91,7 +91,7 @@ public class FileResolverTest {
   public void resolveWildCardFileTest() {
     List<File> files = fileResolver.resolveFiles(realPath + File.separator + "*", realBase);
     assertNotNull("Should not be null", files);
-    assertTrue("files have some files", files.size() > 0);
+    assertTrue("files should have some files", files.size() > 0);
     assertTrue("files contain this class", files.toString().contains(this.getClass().getSimpleName()));
   }
 
@@ -104,7 +104,34 @@ public class FileResolverTest {
 
     files = fileResolver.resolveFiles(realPath + File.separator + "FileResolverTest.class[2]", realBase);
     assertNotNull("Should not be null", files);
-    assertTrue("files have some files", files.size() > 0);
+    assertTrue("files should have some files", files.size() > 0);
     assertTrue("files contain this class", files.toString().contains(this.getClass().getSimpleName()));
+  }
+
+  @Test
+  public void denyDirectoryPathTest() {
+    List<File> files = fileResolver.resolveFiles(realPath, realBase);
+    assertNotNull("Should not be null", files);
+    assertTrue("files should NOT have some files", files.isEmpty());
+
+    List<ILoggingEvent> logsList = listAppender.list;
+    // Check that the 'unclosed' regex was logged - "regex(.*" - should be the first entry in the logs.
+    assertTrue(logsList.get(0).getMessage().startsWith("Cannot include a directory.  Use wildcards to include the contents.  Path="));
+    assertTrue(logsList.get(0).getMessage().startsWith("Cannot include a directory.  Use wildcards to include the contents.  Path="));
+    assertEquals("Severity should be WARN.", Level.ERROR, logsList.get(0).getLevel());
+  }
+
+  @Test
+  public void allowDirectoryPathTest() {
+    String testDirectory = PathUtil.appendPaths(realPath, "rules");
+    FileResolver fileResolverAllow = new FileResolver(realBase, true);
+    List<File> files = fileResolverAllow.resolveFiles(testDirectory, realBase);
+    assertNotNull("Should not be null", files);
+    assertTrue("files should have some files", files.size() > 0);
+
+    List<ILoggingEvent> logsList = listAppender.list;
+    // Check that the 'unclosed' regex was logged - "regex(.*" - should be the first entry in the logs.
+    assertTrue(logsList.get(0).getMessage().startsWith("Including a directory is not recommended.  Instead, use wildcards.  Path="));
+    assertEquals("Severity should be WARN.", Level.WARN, logsList.get(0).getLevel());
   }
 }

--- a/core/src/test/java/com/adobe/aem/dot/common/analyzer/FileResolverTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/common/analyzer/FileResolverTest.java
@@ -72,7 +72,6 @@ public class FileResolverTest {
     assertTrue("files is empty", files.isEmpty());
 
     List<ILoggingEvent> logsList = listAppender.list;
-    // Check that the 'unclosed' regex was logged - "regex(.*" - should be the first entry in the logs.
     assertEquals("Environment variable is not set.  EnvVar=\"{}\"",
             logsList.get(0).getMessage());
     assertEquals("Severity should be WARN.", Level.WARN, logsList.get(0).getLevel());
@@ -128,7 +127,6 @@ public class FileResolverTest {
     assertTrue("files should have some files", files.size() > 0);
 
     List<ILoggingEvent> logsList = listAppender.list;
-    // Check that the 'unclosed' regex was logged - "regex(.*" - should be the first entry in the logs.
     assertTrue(logsList.get(0).getMessage().startsWith("Including a directory is not recommended.  Instead, use wildcards.  Path="));
     assertEquals("Severity should be WARN.", Level.WARN, logsList.get(0).getLevel());
   }

--- a/core/src/test/java/com/adobe/aem/dot/httpd/core/HttpdConfigurationFactoryTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/httpd/core/HttpdConfigurationFactoryTest.java
@@ -74,7 +74,8 @@ public class HttpdConfigurationFactoryTest {
     String classPath = PathEncodingHelper.getDecodedClassPath(this.getClass());
 
     // Provide valid repo path without any 'httpd.conf' files.
-    ConfigurationParseResults results = hcf.getHttpdConfiguration(classPath + File.separator + "helpers", "hi");
+    ConfigurationParseResults<HttpdConfiguration> results = hcf.getHttpdConfiguration(
+            classPath + File.separator + "helpers", "hi");
     assertNull("config not found - null", results);
 
     List<ILoggingEvent> logsList = listAppender.list;

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>com.adobe.aem.dot</groupId>
       <artifactId>dispatcher-optimizer-core</artifactId>
-      <version>1.0.15-SNAPSHOT</version>
+      <version>1.0.17-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
## Description

Apache Httpd "include"'s allow the inclusion of directories and their entire subtree!  This change allows for that.

## Motivation and Context

Handle 'include' the same way as Apache Httpd.

## How Has This Been Tested?

- Two unit tests
- Many customer configurations

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
