### PR TITLE
CEL-312 - Update the validation of /cache /rules to include support for /selectors, /path, /extension, and /suffix

### DIFF
--- a/core/src/main/java/com/adobe/aem/dot/common/analyzer/Check.java
+++ b/core/src/main/java/com/adobe/aem/dot/common/analyzer/Check.java
@@ -24,8 +24,8 @@ import com.adobe.aem.dot.dispatcher.core.analyzer.conditions.IntGreaterOrEqualCh
 import com.adobe.aem.dot.dispatcher.core.analyzer.conditions.IsUniqueLabelCheck;
 import com.adobe.aem.dot.dispatcher.core.analyzer.conditions.RuleListIncludesCheck;
 import com.adobe.aem.dot.dispatcher.core.analyzer.conditions.RuleListStartsWithCheck;
-import com.adobe.aem.dot.dispatcher.core.model.Filter;
-import com.adobe.aem.dot.dispatcher.core.model.Rule;
+import com.adobe.aem.dot.dispatcher.core.model.FilterRule;
+import com.adobe.aem.dot.dispatcher.core.model.GlobRule;
 import com.adobe.aem.dot.httpd.core.analyzer.conditions.HasDirectiveCheck;
 import com.adobe.aem.dot.httpd.core.model.Directive;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -58,8 +58,8 @@ import org.slf4j.LoggerFactory;
 @Setter
 public abstract class Check {
   private String value;
-  private Rule ruleValue;
-  private Filter filterValue;
+  private GlobRule ruleValue;
+  private FilterRule filterValue;
   private Directive directiveValue;
   private String context;
   private boolean failIf = false;

--- a/core/src/main/java/com/adobe/aem/dot/dispatcher/core/analyzer/conditions/FilterListIncludesCheck.java
+++ b/core/src/main/java/com/adobe/aem/dot/dispatcher/core/analyzer/conditions/FilterListIncludesCheck.java
@@ -20,7 +20,7 @@ import com.adobe.aem.dot.common.analyzer.Check;
 import com.adobe.aem.dot.common.analyzer.CheckResult;
 import com.adobe.aem.dot.common.analyzer.Condition;
 import com.adobe.aem.dot.dispatcher.core.model.ConfigurationValue;
-import com.adobe.aem.dot.dispatcher.core.model.Filter;
+import com.adobe.aem.dot.dispatcher.core.model.FilterRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,9 +46,9 @@ public class FilterListIncludesCheck extends Check {
     }
 
     try {
-      ConfigurationValue<List<Filter>> wrappedConfigFilters = (ConfigurationValue<List<Filter>>) configurationValue;
-      List<Filter> configFilters = wrappedConfigFilters.getValue();
-      Filter checkFilter = this.getFilterValue();
+      ConfigurationValue<List<FilterRule>> wrappedConfigFilters = (ConfigurationValue<List<FilterRule>>) configurationValue;
+      List<FilterRule> configFilters = wrappedConfigFilters.getValue();
+      FilterRule checkFilter = this.getFilterValue();
       return new CheckResult(this.processFailIf(configFilters != null && !configFilters.isEmpty() &&
               configFilters.contains(checkFilter)),
               wrappedConfigFilters.getConfigurationSource());

--- a/core/src/main/java/com/adobe/aem/dot/dispatcher/core/analyzer/conditions/FilterListStartsWithCheck.java
+++ b/core/src/main/java/com/adobe/aem/dot/dispatcher/core/analyzer/conditions/FilterListStartsWithCheck.java
@@ -20,7 +20,7 @@ import com.adobe.aem.dot.common.analyzer.Check;
 import com.adobe.aem.dot.common.analyzer.CheckResult;
 import com.adobe.aem.dot.common.analyzer.Condition;
 import com.adobe.aem.dot.dispatcher.core.model.ConfigurationValue;
-import com.adobe.aem.dot.dispatcher.core.model.Filter;
+import com.adobe.aem.dot.dispatcher.core.model.FilterRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,9 +46,9 @@ public class FilterListStartsWithCheck extends Check {
     }
 
     try {
-      ConfigurationValue<List<Filter>> wrappedConfigFilters = (ConfigurationValue<List<Filter>>) configurationValue;
-      List<Filter> configFilters = wrappedConfigFilters.getValue();
-      Filter checkFilter = this.getFilterValue();
+      ConfigurationValue<List<FilterRule>> wrappedConfigFilters = (ConfigurationValue<List<FilterRule>>) configurationValue;
+      List<FilterRule> configFilters = wrappedConfigFilters.getValue();
+      FilterRule checkFilter = this.getFilterValue();
       return new CheckResult(
               this.processFailIf(configFilters != null && !configFilters.isEmpty() &&
                       checkFilter.equals(configFilters.get(0))),

--- a/core/src/main/java/com/adobe/aem/dot/dispatcher/core/analyzer/conditions/RuleListIncludesCheck.java
+++ b/core/src/main/java/com/adobe/aem/dot/dispatcher/core/analyzer/conditions/RuleListIncludesCheck.java
@@ -20,7 +20,7 @@ import com.adobe.aem.dot.common.analyzer.Check;
 import com.adobe.aem.dot.common.analyzer.CheckResult;
 import com.adobe.aem.dot.common.analyzer.Condition;
 import com.adobe.aem.dot.dispatcher.core.model.ConfigurationValue;
-import com.adobe.aem.dot.dispatcher.core.model.Rule;
+import com.adobe.aem.dot.dispatcher.core.model.GlobRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,9 +46,9 @@ public class RuleListIncludesCheck extends Check {
     }
 
     try {
-      ConfigurationValue<List<Rule>> wrappedConfigRules = (ConfigurationValue<List<Rule>>) configurationValue;
-      List<Rule> configRules = wrappedConfigRules.getValue();
-      Rule checkRule = this.getRuleValue();
+      ConfigurationValue<List<GlobRule>> wrappedConfigRules = (ConfigurationValue<List<GlobRule>>) configurationValue;
+      List<GlobRule> configRules = wrappedConfigRules.getValue();
+      GlobRule checkRule = this.getRuleValue();
       return new CheckResult(this.processFailIf(configRules != null && !configRules.isEmpty() &&
               configRules.contains(checkRule)),
               wrappedConfigRules.getConfigurationSource());

--- a/core/src/main/java/com/adobe/aem/dot/dispatcher/core/analyzer/conditions/RuleListStartsWithCheck.java
+++ b/core/src/main/java/com/adobe/aem/dot/dispatcher/core/analyzer/conditions/RuleListStartsWithCheck.java
@@ -20,7 +20,7 @@ import com.adobe.aem.dot.common.analyzer.Check;
 import com.adobe.aem.dot.common.analyzer.CheckResult;
 import com.adobe.aem.dot.common.analyzer.Condition;
 import com.adobe.aem.dot.dispatcher.core.model.ConfigurationValue;
-import com.adobe.aem.dot.dispatcher.core.model.Rule;
+import com.adobe.aem.dot.dispatcher.core.model.GlobRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,9 +46,9 @@ public class RuleListStartsWithCheck extends Check {
     }
 
     try {
-      ConfigurationValue<List<Rule>> wrappedConfigRules = (ConfigurationValue<List<Rule>>) configurationValue;
-      List<Rule> configRules = wrappedConfigRules.getValue();
-      Rule checkRule = this.getRuleValue();
+      ConfigurationValue<List<GlobRule>> wrappedConfigRules = (ConfigurationValue<List<GlobRule>>) configurationValue;
+      List<GlobRule> configRules = wrappedConfigRules.getValue();
+      GlobRule checkRule = this.getRuleValue();
       return new CheckResult(this.processFailIf(configRules != null && !configRules.isEmpty() &&
               checkRule.equals(configRules.get(0))),
               wrappedConfigRules.getConfigurationSource());

--- a/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/AuthChecker.java
+++ b/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/AuthChecker.java
@@ -37,8 +37,8 @@ import java.util.List;
 @Setter(AccessLevel.PRIVATE)
 public class AuthChecker extends LabeledConfigurationValue {
   private ConfigurationValue<String> url;
-  private ConfigurationValue<List<Filter>> filter;
-  private ConfigurationValue<List<Rule>> headers;     // Each /headers are in the form of a Rule (i.e. glob & type)
+  private ConfigurationValue<List<FilterRule>> filter;
+  private ConfigurationValue<List<GlobRule>> headers;     // Each /headers are in the form of a Rule (i.e. glob & type)
 
   private static final Logger logger = LoggerFactory.getLogger(AuthChecker.class);
 
@@ -77,12 +77,12 @@ public class AuthChecker extends LabeledConfigurationValue {
           break;
         case "/filter":
           logger.trace("AuthChecker > filter");
-          ConfigurationValue<List<Filter>> filters = Filter.parseFilters(reader);
+          ConfigurationValue<List<FilterRule>> filters = FilterRule.parseFilters(reader);
           authChecker.setFilter(filters);
           break;
         case "/headers":
           logger.trace("AuthChecker > headers");
-          ConfigurationValue<List<Rule>> tokens = Rule.parseRules(reader);
+          ConfigurationValue<List<GlobRule>> tokens = GlobRule.parseRules(reader);
           authChecker.setHeaders(tokens);
           break;
         case "}":

--- a/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/Cache.java
+++ b/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/Cache.java
@@ -49,7 +49,7 @@ public class Cache {
   private ConfigurationValue<Boolean> serveStaleOnError = DEFAULT_BOOLEAN_FALSE;
   private ConfigurationValue<Integer> gracePeriod = DEFAULT_INT_ZERO;
   private ConfigurationValue<Boolean> enableTTL = DEFAULT_BOOLEAN_FALSE;
-  private ConfigurationValue<List<Rule>> rules;
+  private ConfigurationValue<List<Filter>> rules;
   private ConfigurationValue<List<Rule>> invalidate;
   private ConfigurationValue<String> invalidateHandler;
   private ConfigurationValue<List<Rule>> allowedClients;
@@ -107,7 +107,7 @@ public class Cache {
           break;
         case "/rules":
           logger.trace("cache > rules");
-          ConfigurationValue<List<Rule>> rules = Rule.parseRules(reader);
+          ConfigurationValue<List<Filter>> rules = Filter.parseFilters(reader);
           cache.setRules(rules);
           break;
         case "/invalidate":

--- a/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/Cache.java
+++ b/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/Cache.java
@@ -49,11 +49,11 @@ public class Cache {
   private ConfigurationValue<Boolean> serveStaleOnError = DEFAULT_BOOLEAN_FALSE;
   private ConfigurationValue<Integer> gracePeriod = DEFAULT_INT_ZERO;
   private ConfigurationValue<Boolean> enableTTL = DEFAULT_BOOLEAN_FALSE;
-  private ConfigurationValue<List<Filter>> rules;
-  private ConfigurationValue<List<Rule>> invalidate;
+  private ConfigurationValue<List<FilterRule>> rules;
+  private ConfigurationValue<List<GlobRule>> invalidate;
   private ConfigurationValue<String> invalidateHandler;
-  private ConfigurationValue<List<Rule>> allowedClients;
-  private ConfigurationValue<List<Rule>> ignoreUrlParams;
+  private ConfigurationValue<List<GlobRule>> allowedClients;
+  private ConfigurationValue<List<GlobRule>> ignoreUrlParams;
   private List<ConfigurationValue<String>> headers;
   private ConfigurationValue<String> mode = new ConfigurationValue<>(DEFAULT_MODE_VALUE, DEFAULT_VALUE_FILE_NAME, 0);
 
@@ -107,12 +107,12 @@ public class Cache {
           break;
         case "/rules":
           logger.trace("cache > rules");
-          ConfigurationValue<List<Filter>> rules = Filter.parseFilters(reader);
+          ConfigurationValue<List<FilterRule>> rules = FilterRule.parseFilters(reader);
           cache.setRules(rules);
           break;
         case "/invalidate":
           logger.trace("cache > invalidate");
-          ConfigurationValue<List<Rule>> invalidateRules = Rule.parseRules(reader);
+          ConfigurationValue<List<GlobRule>> invalidateRules = GlobRule.parseRules(reader);
           cache.setInvalidate(invalidateRules);
           break;
         case "/invalidateHandler":
@@ -127,12 +127,12 @@ public class Cache {
           break;
         case "/allowedClients":
           logger.trace("cache > allowedClients");
-          ConfigurationValue<List<Rule>> allowedClients = Rule.parseRules(reader);
+          ConfigurationValue<List<GlobRule>> allowedClients = GlobRule.parseRules(reader);
           cache.setAllowedClients(allowedClients);
           break;
         case "/ignoreUrlParams":
           logger.trace("cache > ignoreUrlParams");
-          ConfigurationValue<List<Rule>> ignoreUrlParams = Rule.parseRules(reader);
+          ConfigurationValue<List<GlobRule>> ignoreUrlParams = GlobRule.parseRules(reader);
           cache.setIgnoreUrlParams(ignoreUrlParams);
           break;
         case "/headers":

--- a/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/Farm.java
+++ b/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/Farm.java
@@ -28,7 +28,6 @@ import lombok.Setter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -48,7 +47,7 @@ public class Farm extends LabeledConfigurationValue {
   private List<ConfigurationValue<String>> clientHeaders;
   private List<ConfigurationValue<String>> virtualHosts;
   private ConfigurationValue<List<Render>> renders;
-  private ConfigurationValue<List<Filter>> filter;
+  private ConfigurationValue<List<FilterRule>> filter;
   private ConfigurationValue<Cache> cache;
   private ConfigurationValue<Statistics> statistics;
   private ConfigurationValue<VanityUrls> vanityUrls;
@@ -201,7 +200,7 @@ public class Farm extends LabeledConfigurationValue {
           break;
         case "/filter":
           logger.trace("farm > filter");
-          ConfigurationValue<List<Filter>> filters = Filter.parseFilters(reader);
+          ConfigurationValue<List<FilterRule>> filters = FilterRule.parseFilters(reader);
           farm.setFilter(filters);
           break;
         case "/cache":

--- a/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/Filter.java
+++ b/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/Filter.java
@@ -213,7 +213,7 @@ public class Filter extends LabeledConfigurationValue {
     // Expect { to begin the filter block, unless there is no label.
     if (!skipLabel) {
       if (!reader.isNextChar('{', false)) {
-        FeedbackProcessor.error(logger,"Each filter must begin with a '{' character.",
+        FeedbackProcessor.error(logger,"Each filter rule must begin with a '{' character.",
                 reader.getCurrentConfigurationValue(), Severity.MAJOR);
         return new Filter();
       }
@@ -297,7 +297,8 @@ public class Filter extends LabeledConfigurationValue {
   @Override
   public String toString() {
     StringBuilder str = new StringBuilder();
-    appendIfNotEmpty(str, "Type", getType() == null ? null : getType().toString(), true);
+    appendIfNotEmpty(str, "Label", getLabel(), true);
+    appendIfNotEmpty(str, "Type", getType() == null ? null : getType().toString(), false);
     appendIfNotEmpty(str, "URL", getUrl(), false);
     appendIfNotEmpty(str, "Extension", getExtension(), false);
     appendIfNotEmpty(str, "Selectors", getSelectors(), false);

--- a/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/FilterRule.java
+++ b/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/FilterRule.java
@@ -37,7 +37,7 @@ import java.util.List;
  */
 @Getter
 @Setter(AccessLevel.PRIVATE)
-public class Filter extends LabeledConfigurationValue {
+public class FilterRule extends LabeledConfigurationValue {
   private ConfigurationValue<RuleType> type;
   private ConfigurationValue<String> url;
   private ConfigurationValue<String> extension;
@@ -48,7 +48,7 @@ public class Filter extends LabeledConfigurationValue {
   private ConfigurationValue<String> query;
   private ConfigurationValue<String> glob;
 
-  private static final Logger logger = LoggerFactory.getLogger(Filter.class.getName());
+  private static final Logger logger = LoggerFactory.getLogger(FilterRule.class.getName());
 
   Logger getLogger() {
     return logger;
@@ -136,7 +136,7 @@ public class Filter extends LabeledConfigurationValue {
 
     if (o == null || getClass() != o.getClass()) return false;
 
-    Filter filter = (Filter) o;
+    FilterRule filter = (FilterRule) o;
 
     return new MatchesBuilder()
             .append(getType(), filter.getType())
@@ -165,8 +165,8 @@ public class Filter extends LabeledConfigurationValue {
             .toHashCode();
   }
 
-  static ConfigurationValue<List<Filter>> parseFilters(ConfigurationReader reader) throws ConfigurationSyntaxException {
-    List<Filter> filters = new ArrayList<>();
+  static ConfigurationValue<List<FilterRule>> parseFilters(ConfigurationReader reader) throws ConfigurationSyntaxException {
+    List<FilterRule> filters = new ArrayList<>();
 
     // Expect { to begin the block
     if (!reader.isNextChar('{', false)) {
@@ -190,7 +190,7 @@ public class Filter extends LabeledConfigurationValue {
       } else {
         // If the next character is a open brace, the label (/0001) was skipped.
         boolean missingLabel = currentToken.getValue().equals("{");
-        Filter filter = Filter.parseFilter(reader, missingLabel);
+        FilterRule filter = FilterRule.parseFilter(reader, missingLabel);
         if (missingLabel) {
           FeedbackProcessor.info(logger, "Label on Filter is missing.", currentToken);
         } else {
@@ -205,9 +205,9 @@ public class Filter extends LabeledConfigurationValue {
             firstToken.getFileName(), firstToken.getLineNumber(), firstToken.getIncludedFrom());
   }
 
-  private static Filter parseFilter(ConfigurationReader reader, boolean skipLabel)
+  private static FilterRule parseFilter(ConfigurationReader reader, boolean skipLabel)
           throws ConfigurationSyntaxException {
-    Filter filter = new Filter();
+    FilterRule filter = new FilterRule();
     ConfigurationValue<String> nextToken;
 
     // Expect { to begin the filter block, unless there is no label.
@@ -215,7 +215,7 @@ public class Filter extends LabeledConfigurationValue {
       if (!reader.isNextChar('{', false)) {
         FeedbackProcessor.error(logger,"Each filter rule must begin with a '{' character.",
                 reader.getCurrentConfigurationValue(), Severity.MAJOR);
-        return new Filter();
+        return new FilterRule();
       }
       reader.next(); // Advance the reader's pointer passed the "{" marker.
     }

--- a/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/GlobRule.java
+++ b/core/src/main/java/com/adobe/aem/dot/dispatcher/core/model/GlobRule.java
@@ -38,13 +38,13 @@ import java.util.List;
  */
 @Getter
 @Setter(AccessLevel.PRIVATE)
-public class Rule extends LabeledConfigurationValue {
+public class GlobRule extends LabeledConfigurationValue {
   private ConfigurationValue<String> glob;
   private ConfigurationValue<RuleType> type;
 
-  private static final Logger logger = LoggerFactory.getLogger(Rule.class);
+  private static final Logger logger = LoggerFactory.getLogger(GlobRule.class);
 
-  public Rule() {  }
+  public GlobRule() {  }
 
   Logger getLogger() {
     return logger;
@@ -80,8 +80,8 @@ public class Rule extends LabeledConfigurationValue {
     this.type = new ConfigurationValue<>(RuleType.valueOf(type));
   }
 
-  static ConfigurationValue<List<Rule>> parseRules(ConfigurationReader reader) throws ConfigurationSyntaxException {
-    List<Rule> rules = new ArrayList<>();
+  static ConfigurationValue<List<GlobRule>> parseRules(ConfigurationReader reader) throws ConfigurationSyntaxException {
+    List<GlobRule> rules = new ArrayList<>();
 
     // Expect { to begin the block
     if (!reader.isNextChar('{', false)) {
@@ -105,7 +105,7 @@ public class Rule extends LabeledConfigurationValue {
       } else {
         // If the next character is a open brace, the label (/0001) was skipped.
         boolean missingLabel = currentToken.getValue().equals("{");
-        Rule rule = Rule.parseRule(reader, missingLabel);
+        GlobRule rule = GlobRule.parseRule(reader, missingLabel);
         if (missingLabel) {
           FeedbackProcessor.info(logger, "Label on Rule is missing.", currentToken);
         } else {
@@ -120,8 +120,8 @@ public class Rule extends LabeledConfigurationValue {
             firstToken.getFileName(), firstToken.getLineNumber(), firstToken.getIncludedFrom());
   }
 
-  private static Rule parseRule(ConfigurationReader reader, boolean skipLabel) throws ConfigurationSyntaxException {
-    Rule rule = new Rule();
+  private static GlobRule parseRule(ConfigurationReader reader, boolean skipLabel) throws ConfigurationSyntaxException {
+    GlobRule rule = new GlobRule();
     ConfigurationValue<String> nextToken;
 
     // Expect { to begin the rule block, unless there is no label.
@@ -129,7 +129,7 @@ public class Rule extends LabeledConfigurationValue {
       if (!reader.isNextChar('{', false)) {
         FeedbackProcessor.error(logger,"Each rule must begin with a '{' character.",
                 reader.getCurrentConfigurationValue(), Severity.MAJOR);
-        return new Rule();
+        return new GlobRule();
       }
       reader.next(); // Advance the reader's pointer passed the "{" marker.
     }
@@ -177,7 +177,7 @@ public class Rule extends LabeledConfigurationValue {
 
     if (o == null || getClass() != o.getClass()) return false;
 
-    Rule rule = (Rule) o;
+    GlobRule rule = (GlobRule) o;
 
     return new MatchesBuilder()
             .append(getGlob(), rule.getGlob())

--- a/core/src/main/java/com/adobe/aem/dot/httpd/core/parser/HttpdConfigurationParser.java
+++ b/core/src/main/java/com/adobe/aem/dot/httpd/core/parser/HttpdConfigurationParser.java
@@ -341,7 +341,7 @@ public class HttpdConfigurationParser {
 
       if (!optional) {
         throw new FileNotFoundException(
-                MessageFormat.format("Configuration file was not found.  File=\"{}\"", configFile.getPath()));
+                MessageFormat.format("Configuration file was not found.  File=\"{0}\"", configFile.getPath()));
       }
     }
   }

--- a/core/src/test/java/com/adobe/aem/dot/common/analyzer/AnalyzerRuleTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/common/analyzer/AnalyzerRuleTest.java
@@ -23,7 +23,7 @@ import com.adobe.aem.dot.dispatcher.core.DispatcherConstants;
 import com.adobe.aem.dot.dispatcher.core.model.ConfigurationValue;
 import com.adobe.aem.dot.dispatcher.core.model.DispatcherConfiguration;
 import com.adobe.aem.dot.dispatcher.core.model.Farm;
-import com.adobe.aem.dot.dispatcher.core.model.Filter;
+import com.adobe.aem.dot.dispatcher.core.model.FilterRule;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -79,7 +79,7 @@ public class AnalyzerRuleTest {
     // Change the rule's element to farm.filter
     testRule1.setElement("farm.filter");
     checkTarget = testRule1.determineCheckTarget(farm);
-    ConfigurationValue<List<Filter>> filtersTarget = (ConfigurationValue<List<Filter>>) checkTarget;
+    ConfigurationValue<List<FilterRule>> filtersTarget = (ConfigurationValue<List<FilterRule>>) checkTarget;
     assertEquals("Should extract the list of filters from the farm", "/content/test-filter/*",
             filtersTarget.getValue().get(0).getGlob());
   }

--- a/core/src/test/java/com/adobe/aem/dot/common/analyzer/rules/AMSFiltersRuleTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/common/analyzer/rules/AMSFiltersRuleTest.java
@@ -29,7 +29,7 @@ import com.adobe.aem.dot.dispatcher.core.analyzer.conditions.FilterListIncludesC
 import com.adobe.aem.dot.dispatcher.core.analyzer.conditions.FilterListStartsWithCheck;
 import com.adobe.aem.dot.dispatcher.core.model.ConfigurationValue;
 import com.adobe.aem.dot.dispatcher.core.model.DispatcherConfiguration;
-import com.adobe.aem.dot.dispatcher.core.model.Filter;
+import com.adobe.aem.dot.dispatcher.core.model.FilterRule;
 import com.adobe.aem.dot.dispatcher.core.model.RuleType;
 import org.junit.Assert;
 import org.junit.Before;
@@ -50,8 +50,8 @@ public class AMSFiltersRuleTest {
 
   private AnalyzerRule amsFiltersRule;
   private RuleProcessor ruleProcessor;
-  private Filter denyAllUrls;
-  private Filter anyAllowWithMethodCondition;
+  private FilterRule denyAllUrls;
+  private FilterRule anyAllowWithMethodCondition;
   private Check check1;
   private Check check2;
 
@@ -61,7 +61,7 @@ public class AMSFiltersRuleTest {
     // 1st check
     this.check1 = new FilterListStartsWithCheck();
     // Expect a DENY of /url "*" as the first filter
-    denyAllUrls = new Filter();
+    denyAllUrls = new FilterRule();
     denyAllUrls.setType(new ConfigurationValue<>(RuleType.DENY, "AMSFiltersRuleTest.any", 1));
     denyAllUrls.setUrl(new ConfigurationValue<>("*", "AMSFiltersRuleTest.any", 2));
     this.check1.setFilterValue(denyAllUrls);
@@ -69,7 +69,7 @@ public class AMSFiltersRuleTest {
     // 2nd check
     this.check2 = new FilterListIncludesCheck();
     // Expect a DENY of a number of selectors & extensions next
-    Filter denyContentGrabbing = new Filter();
+    FilterRule denyContentGrabbing = new FilterRule();
     denyContentGrabbing.setType(new ConfigurationValue<>(RuleType.DENY, "AMSFiltersRuleTest.any", 3));
     denyContentGrabbing.setExtension(new ConfigurationValue<>("(json|xml|html|feed)", "AMSFiltersRuleTest.any", 4));
     denyContentGrabbing.setSelectors(new ConfigurationValue<>("(feed|rss|pages|languages|blueprint|infinity|tidy|sysview|docview|query|[0-9-]+|jcr:content)", "AMSFiltersRuleTest.any", 5));
@@ -91,7 +91,7 @@ public class AMSFiltersRuleTest {
      *   }
      * }
      */
-    anyAllowWithMethodCondition = new Filter();
+    anyAllowWithMethodCondition = new FilterRule();
     anyAllowWithMethodCondition.setType(new ConfigurationValue<>(RuleType.ALLOW, "AMSFiltersRuleTest.any", 6));
     anyAllowWithMethodCondition.setMethod(new ConfigurationValue<>("regex(.*)", "AMSFiltersRuleTest.any", 7));
 

--- a/core/src/test/java/com/adobe/aem/dot/common/analyzer/rules/IgnoreUrlParamsAllowListRuleTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/common/analyzer/rules/IgnoreUrlParamsAllowListRuleTest.java
@@ -35,7 +35,7 @@ import com.adobe.aem.dot.dispatcher.core.analyzer.conditions.RuleListIncludesChe
 import com.adobe.aem.dot.dispatcher.core.analyzer.conditions.RuleListStartsWithCheck;
 import com.adobe.aem.dot.dispatcher.core.model.ConfigurationValue;
 import com.adobe.aem.dot.dispatcher.core.model.DispatcherConfiguration;
-import com.adobe.aem.dot.dispatcher.core.model.Rule;
+import com.adobe.aem.dot.dispatcher.core.model.GlobRule;
 import com.adobe.aem.dot.dispatcher.core.model.RuleType;
 import org.junit.Assert;
 import org.junit.Before;
@@ -234,8 +234,8 @@ public class IgnoreUrlParamsAllowListRuleTest {
     assertEquals("Severity should be ERROR.", Level.ERROR, logsList.get(2).getLevel());
   }
 
-  private Rule createRule(String label, String glob, RuleType type) {
-    Rule rule = new Rule();
+  private GlobRule createRule(String label, String glob, RuleType type) {
+    GlobRule rule = new GlobRule();
     rule.setLabel(new ConfigurationValue<>(label, "IgnoreUrlParamsAllowListRuleTest.any", 1));
     rule.setGlob(new ConfigurationValue<>(glob, "IgnoreUrlParamsAllowListRuleTest.any", 2));
     rule.setType(new ConfigurationValue<>(type, "IgnoreUrlParamsAllowListRuleTest.any", 3));

--- a/core/src/test/java/com/adobe/aem/dot/dispatcher/core/ConfigurationParserTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/dispatcher/core/ConfigurationParserTest.java
@@ -157,11 +157,11 @@ public class ConfigurationParserTest {
   public void shouldParseCacheRules() {
     Cache cache = basicConfig.getFarms().get(0).getValue().getCache().getValue();
     // Check source
-    Rule rule1 = cache.getRules().getValue().get(0);
+    Filter rule1 = cache.getRules().getValue().get(0);
     assertEquals("Expect rule glob to be parsed", "*", rule1.getGlob());
     assertEquals("Expect rule type to be parsed", RuleType.DENY, rule1.getType());
 
-    Rule rule2 = cache.getRules().getValue().get(1);
+    Filter rule2 = cache.getRules().getValue().get(1);
     assertEquals("Expect rule glob to be parsed", "/content/*", rule2.getGlob());
     assertEquals("Expect rule type to be parsed", RuleType.ALLOW, rule2.getType());
   }

--- a/core/src/test/java/com/adobe/aem/dot/dispatcher/core/ConfigurationParserTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/dispatcher/core/ConfigurationParserTest.java
@@ -22,9 +22,9 @@ import com.adobe.aem.dot.dispatcher.core.model.Cache;
 import com.adobe.aem.dot.dispatcher.core.model.ConfigurationValue;
 import com.adobe.aem.dot.dispatcher.core.model.DispatcherConfiguration;
 import com.adobe.aem.dot.dispatcher.core.model.Farm;
-import com.adobe.aem.dot.dispatcher.core.model.Filter;
+import com.adobe.aem.dot.dispatcher.core.model.FilterRule;
 import com.adobe.aem.dot.dispatcher.core.model.Render;
-import com.adobe.aem.dot.dispatcher.core.model.Rule;
+import com.adobe.aem.dot.dispatcher.core.model.GlobRule;
 import com.adobe.aem.dot.dispatcher.core.model.RuleType;
 import com.adobe.aem.dot.dispatcher.core.model.Statistics;
 import com.adobe.aem.dot.dispatcher.core.model.StatisticsRule;
@@ -116,7 +116,7 @@ public class ConfigurationParserTest {
 
   @Test
   public void shouldParseFilterRules() {
-    Filter filter1 = basicConfig.getFarms().get(0).getValue().getFilter().getValue().get(0);
+    FilterRule filter1 = basicConfig.getFarms().get(0).getValue().getFilter().getValue().get(0);
     assertEquals("Expect name to be parsed", "0001", filter1.getLabel());
 
     // type
@@ -124,7 +124,7 @@ public class ConfigurationParserTest {
     // url
     assertEquals("Expect url to be parsed", "*", filter1.getUrl());
 
-    Filter filter2 = basicConfig.getFarms().get(0).getValue().getFilter().getValue().get(1);
+    FilterRule filter2 = basicConfig.getFarms().get(0).getValue().getFilter().getValue().get(1);
     assertEquals("Expect name to be parsed", "0002", filter2.getLabel());
 
     // type
@@ -135,7 +135,7 @@ public class ConfigurationParserTest {
     // path
     assertEquals("Expect path to be parsed", "/content/dispatchertester", filter2.getPath());
 
-    Filter filter3 = basicConfig.getFarms().get(0).getValue().getFilter().getValue().get(2);
+    FilterRule filter3 = basicConfig.getFarms().get(0).getValue().getFilter().getValue().get(2);
     assertEquals("Expect suffix to be parsed", "*", filter3.getSuffix());
   }
 
@@ -157,11 +157,11 @@ public class ConfigurationParserTest {
   public void shouldParseCacheRules() {
     Cache cache = basicConfig.getFarms().get(0).getValue().getCache().getValue();
     // Check source
-    Filter rule1 = cache.getRules().getValue().get(0);
+    FilterRule rule1 = cache.getRules().getValue().get(0);
     assertEquals("Expect rule glob to be parsed", "*", rule1.getGlob());
     assertEquals("Expect rule type to be parsed", RuleType.DENY, rule1.getType());
 
-    Filter rule2 = cache.getRules().getValue().get(1);
+    FilterRule rule2 = cache.getRules().getValue().get(1);
     assertEquals("Expect rule glob to be parsed", "/content/*", rule2.getGlob());
     assertEquals("Expect rule type to be parsed", RuleType.ALLOW, rule2.getType());
   }
@@ -169,13 +169,13 @@ public class ConfigurationParserTest {
   @Test
   public void shouldParseCacheInvalidateRules() {
     Cache cache = basicConfig.getFarms().get(0).getValue().getCache().getValue();
-    Rule rule1 = cache.getInvalidate().getValue().get(0);
+    GlobRule rule1 = cache.getInvalidate().getValue().get(0);
     assertEquals("Expect rule name to be parsed", "0000", rule1.getLabel());
     assertEquals("Expect rule glob to be parsed", "*", rule1.getGlob());
     assertEquals("Expect rule type to be parsed", RuleType.DENY, rule1.getType());
 
 
-    Rule rule3 = cache.getInvalidate().getValue().get(2);
+    GlobRule rule3 = cache.getInvalidate().getValue().get(2);
     assertEquals("Expect rule name to be parsed", "0002", rule3.getLabel());
     assertEquals("Expect rule glob to be parsed", "/etc/segmentation.segment.js", rule3.getGlob());
     assertEquals("Expect rule type to be parsed", RuleType.ALLOW, rule3.getType());
@@ -184,13 +184,13 @@ public class ConfigurationParserTest {
   @Test
   public void shouldParseCacheAllowedClientsRules() {
     Cache cache = basicConfig.getFarms().get(0).getValue().getCache().getValue();
-    Rule rule1 = cache.getAllowedClients().getValue().get(0);
+    GlobRule rule1 = cache.getAllowedClients().getValue().get(0);
     assertEquals("Expect rule name to be parsed", "0000", rule1.getLabel());
     assertEquals("Expect rule glob to be parsed", "*", rule1.getGlob());
     assertEquals("Expect rule type to be parsed", RuleType.DENY, rule1.getType());
 
 
-    Rule rule2 = cache.getAllowedClients().getValue().get(1);
+    GlobRule rule2 = cache.getAllowedClients().getValue().get(1);
     assertEquals("Expect rule name to be parsed", "0001", rule2.getLabel());
     assertEquals("Expect rule glob to be parsed", "127.0.0.1", rule2.getGlob());
     assertEquals("Expect rule type to be parsed", RuleType.ALLOW, rule2.getType());
@@ -199,13 +199,13 @@ public class ConfigurationParserTest {
   @Test
   public void shouldParseCacheIgnoreUrlParamsRules() {
     Cache cache = basicConfig.getFarms().get(0).getValue().getCache().getValue();
-    Rule rule1 = cache.getIgnoreUrlParams().getValue().get(0);
+    GlobRule rule1 = cache.getIgnoreUrlParams().getValue().get(0);
     assertEquals("Expect rule name to be parsed", "0101", rule1.getLabel());
     assertEquals("Expect rule glob to be parsed", "*", rule1.getGlob());
     assertEquals("Expect rule type to be parsed", RuleType.ALLOW, rule1.getType());
 
 
-    Rule rule2 = cache.getIgnoreUrlParams().getValue().get(1);
+    GlobRule rule2 = cache.getIgnoreUrlParams().getValue().get(1);
     assertEquals("Expect rule name to be parsed", "0202", rule2.getLabel());
     assertEquals("Expect rule glob to be parsed", "q", rule2.getGlob());
     assertEquals("Expect rule type to be parsed", RuleType.DENY, rule2.getType());

--- a/core/src/test/java/com/adobe/aem/dot/dispatcher/core/analyzer/conditions/FilterListIncludesCheckTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/dispatcher/core/analyzer/conditions/FilterListIncludesCheckTest.java
@@ -28,7 +28,7 @@ import com.adobe.aem.dot.common.parser.ConfigurationParseResults;
 import com.adobe.aem.dot.common.util.PathUtil;
 import com.adobe.aem.dot.dispatcher.core.DispatcherConstants;
 import com.adobe.aem.dot.dispatcher.core.model.DispatcherConfiguration;
-import com.adobe.aem.dot.dispatcher.core.model.Filter;
+import com.adobe.aem.dot.dispatcher.core.model.FilterRule;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -62,7 +62,7 @@ public class FilterListIncludesCheckTest {
 
   @Test
   public void emptyListCase() {
-    List<Filter> list = new ArrayList<>();
+    List<FilterRule> list = new ArrayList<>();
     FilterListIncludesCheck check = new FilterListIncludesCheck();
     CheckResult checkResult = check.performCheck(list);
     assertFalse("empty list value should be negative", checkResult.isPassed());

--- a/core/src/test/java/com/adobe/aem/dot/dispatcher/core/analyzer/conditions/FilterListStartsWithCheckTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/dispatcher/core/analyzer/conditions/FilterListStartsWithCheckTest.java
@@ -28,7 +28,7 @@ import com.adobe.aem.dot.common.parser.ConfigurationParseResults;
 import com.adobe.aem.dot.common.util.PathUtil;
 import com.adobe.aem.dot.dispatcher.core.DispatcherConstants;
 import com.adobe.aem.dot.dispatcher.core.model.DispatcherConfiguration;
-import com.adobe.aem.dot.dispatcher.core.model.Filter;
+import com.adobe.aem.dot.dispatcher.core.model.FilterRule;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -62,7 +62,7 @@ public class FilterListStartsWithCheckTest {
 
   @Test
   public void emptyListCase() {
-    List<Filter> list = new ArrayList<>();
+    List<FilterRule> list = new ArrayList<>();
     FilterListStartsWithCheck check = new FilterListStartsWithCheck();
     CheckResult checkResult = check.performCheck(list);
     assertFalse("empty list value should be negative", checkResult.isPassed());

--- a/core/src/test/java/com/adobe/aem/dot/dispatcher/core/analyzer/conditions/RuleListIncludesCheckTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/dispatcher/core/analyzer/conditions/RuleListIncludesCheckTest.java
@@ -28,7 +28,7 @@ import com.adobe.aem.dot.common.parser.ConfigurationParseResults;
 import com.adobe.aem.dot.common.util.PathUtil;
 import com.adobe.aem.dot.dispatcher.core.DispatcherConstants;
 import com.adobe.aem.dot.dispatcher.core.model.DispatcherConfiguration;
-import com.adobe.aem.dot.dispatcher.core.model.Filter;
+import com.adobe.aem.dot.dispatcher.core.model.FilterRule;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -62,7 +62,7 @@ public class RuleListIncludesCheckTest {
 
   @Test
   public void emptyListCase() {
-    List<Filter> list = new ArrayList<>();
+    List<FilterRule> list = new ArrayList<>();
     RuleListIncludesCheck check = new RuleListIncludesCheck();
     CheckResult checkResult = check.performCheck(list);
     assertFalse("empty list value should be negative", checkResult.isPassed());

--- a/core/src/test/java/com/adobe/aem/dot/dispatcher/core/analyzer/conditions/RuleListStartsWithCheckTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/dispatcher/core/analyzer/conditions/RuleListStartsWithCheckTest.java
@@ -28,7 +28,7 @@ import com.adobe.aem.dot.common.parser.ConfigurationParseResults;
 import com.adobe.aem.dot.common.util.PathUtil;
 import com.adobe.aem.dot.dispatcher.core.DispatcherConstants;
 import com.adobe.aem.dot.dispatcher.core.model.DispatcherConfiguration;
-import com.adobe.aem.dot.dispatcher.core.model.Rule;
+import com.adobe.aem.dot.dispatcher.core.model.GlobRule;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -62,7 +62,7 @@ public class RuleListStartsWithCheckTest {
 
   @Test
   public void emptyListCase() {
-    List<Rule> list = new ArrayList<>();
+    List<GlobRule> list = new ArrayList<>();
     RuleListStartsWithCheck check = new RuleListStartsWithCheck();
     CheckResult checkResult = check.performCheck(list);
     assertFalse("empty list value should be negative", checkResult.isPassed());

--- a/core/src/test/java/com/adobe/aem/dot/dispatcher/core/model/FilterTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/dispatcher/core/model/FilterTest.java
@@ -138,11 +138,11 @@ public class FilterTest {
 
       Filter sixth = filters.get(5);
       assertNull("Null type", sixth.getType());
-      assertTrue("Very empty", sixth.toString().isEmpty());
+      assertEquals("Empty, aside from the label", "Label=nobrace", sixth.toString());
 
       Filter seventh = filters.get(6);
       assertNull("Null type", seventh.getType());
-      assertEquals("Equals without type", ",Suffix=top,Method=get,Glob=*top", seventh.toString());
+      assertEquals("Equals without type", "Label=notype,Suffix=top,Method=get,Glob=*top", seventh.toString());
       assertFalse("different class", seventh.equals(new FeedbackProcessor()));
       assertFalse("null", seventh.equals(null));
       assertNotEquals("hashcode", 0, seventh.hashCode());

--- a/core/src/test/java/com/adobe/aem/dot/dispatcher/core/model/FilterTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/dispatcher/core/model/FilterTest.java
@@ -56,7 +56,7 @@ public class FilterTest {
   @Before
   public void before() {
     // Get Logback Logger: create and start a ListAppender
-    listAppender = AssertHelper.getLogAppender(Filter.class);
+    listAppender = AssertHelper.getLogAppender(FilterRule.class);
   }
 
 
@@ -77,13 +77,13 @@ public class FilterTest {
       assertEquals("Should be 1 farm", 1, config.getFarms().size());
 
       Farm farm = config.getFarms().get(0).getValue();
-      List<Filter> filters = farm.getFilter().getValue();
+      List<FilterRule> filters = farm.getFilter().getValue();
       assertNotNull(filters);
 
       assertEquals("Check filter size", 7, filters.size());
 
       // Check Filter values
-      Filter first = filters.get(0);
+      FilterRule first = filters.get(0);
       assertEquals("Check label 1", "0001", first.getLabel());
       assertNull("Url 1 is null", first.getUrl());
       assertEquals("Check glob 1", "*", first.getGlob());
@@ -99,20 +99,20 @@ public class FilterTest {
       assertEquals("Try the equals()", first, first);
       assertNotEquals("Try the equals()", new FeedbackProcessor(), first);  // Equals on different class.
 
-      Filter second = filters.get(1);
+      FilterRule second = filters.get(1);
       assertEquals("Check label 2", "0002", second.getLabel());
       assertNull("Glob 2 is null", second.getGlob());
       assertEquals("Check glob 2", "/libs/cq/workflow/content/console*", second.getUrl());
       assertEquals("Check type 2", RuleType.ALLOW, second.getType());
 
-      Filter third = filters.get(2);
+      FilterRule third = filters.get(2);
       assertEquals("Check label 3", "hi", third.getLabel());
       assertNull("Glob 3 is null", third.getGlob());
       assertEquals("Check glob 3", "*.asp", third.getUrl());
       assertEquals("Check type 3", RuleType.DENY, third.getType());
       assertEquals("Check path 3", "a_path", third.getPath());
 
-      Filter fourth = filters.get(3);
+      FilterRule fourth = filters.get(3);
       assertEquals("Check label 4", "there", fourth.getLabel());
       assertNull("Glob 4 is null", fourth.getGlob());
       assertEquals("Check glob 4", "/content/[.]*.form.html", fourth.getUrl());
@@ -123,7 +123,7 @@ public class FilterTest {
       assertNull("Check suffix 4", fourth.getSuffix());
       assertNull("Check selectors 4", fourth.getSelectors());
 
-      Filter fifth = filters.get(4);
+      FilterRule fifth = filters.get(4);
       assertEquals("Check label 5", "tester", fifth.getLabel());
       assertNull("Glob 5 is null", fifth.getGlob());
       assertEquals("Check glob 5", "/huh", fifth.getUrl());
@@ -136,11 +136,11 @@ public class FilterTest {
       fifth.setGlob("*");
       assertEquals("Check glob", "*", fifth.getGlob());
 
-      Filter sixth = filters.get(5);
+      FilterRule sixth = filters.get(5);
       assertNull("Null type", sixth.getType());
       assertEquals("Empty, aside from the label", "Label=nobrace", sixth.toString());
 
-      Filter seventh = filters.get(6);
+      FilterRule seventh = filters.get(6);
       assertNull("Null type", seventh.getType());
       assertEquals("Equals without type", "Label=notype,Suffix=top,Method=get,Glob=*top", seventh.toString());
       assertFalse("different class", seventh.equals(new FeedbackProcessor()));
@@ -166,7 +166,7 @@ public class FilterTest {
       assertEquals("Should be 1 farm", 1, config.getFarms().size());
 
       Farm farm = config.getFarms().get(0).getValue();
-      List<Filter> filters = farm.getFilter().getValue();
+      List<FilterRule> filters = farm.getFilter().getValue();
       assertNotNull(filters);
 
       assertEquals("Check filter size", 3, filters.size());
@@ -197,12 +197,12 @@ public class FilterTest {
 
   @Test
   public void filterSelectorSuffixDifferenceNotEqual() {
-    Filter selectorFilter = new Filter();
+    FilterRule selectorFilter = new FilterRule();
     selectorFilter.setType("DENY");
     selectorFilter.setURL("/content*");
     selectorFilter.setSelectors("*");
 
-    Filter suffixFilter = new Filter();
+    FilterRule suffixFilter = new FilterRule();
     suffixFilter.setType("DENY");
     suffixFilter.setURL("/content*");
     suffixFilter.setSuffix("*");

--- a/core/src/test/java/com/adobe/aem/dot/dispatcher/core/model/RuleTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/dispatcher/core/model/RuleTest.java
@@ -52,7 +52,7 @@ public class RuleTest {
   @Before
   public void before() {
     // Get Logback Logger: create and start a ListAppender
-    listAppender = AssertHelper.getLogAppender(Rule.class);
+    listAppender = AssertHelper.getLogAppender(Filter.class);
   }
 
   @BeforeClass
@@ -86,13 +86,13 @@ public class RuleTest {
       assertNotEquals("Try the hashcode()", "hello", cache.hashCode());
       // ====================================================================
 
-      List<Rule> rules = cache.getRules().getValue();
+      List<Filter> rules = cache.getRules().getValue();
       assertNotNull(rules);
 
       assertEquals("Check filter size", 4, rules.size());
 
       // Check Rule values
-      Rule first = rules.get(0);
+      Filter first = rules.get(0);
       assertEquals("Check label 1", "0000", first.getLabel());
       assertEquals("Check glob 1", "*", first.getGlob());
       assertEquals("Check type 1", RuleType.ALLOW, first.getType());
@@ -107,7 +107,7 @@ public class RuleTest {
       assertNotNull("Should be a logger", first.getLogger());
       assertNotNull("Should be a class name", first.getSimpleClassName());
 
-      Rule second = rules.get(1);
+      Filter second = rules.get(1);
       assertEquals("Check label 2", "stout", second.getLabel());
       assertEquals("Check glob 2", "/en/news/'*?lang=en", second.getGlob());
       assertEquals("Check type 2", RuleType.DENY, second.getType());
@@ -118,11 +118,11 @@ public class RuleTest {
               second.getLabelData().getIncludedFrom());
       assertEquals("equals itself", second, second);
 
-      Rule third = rules.get(2);
+      Filter third = rules.get(2);
       assertNull("Null type", third.getType());
-      assertEquals("Equals without type", ",Label=notype", third.toString());
+      assertEquals("Equals without type", "Label=notype,Method=get", third.toString());
 
-      Rule fourth = rules.get(3);
+      Filter fourth = rules.get(3);
       assertTrue("Check label 3", StringUtils.isEmpty(fourth.getLabel()));
       assertEquals("Check glob 3", "*/private/*", fourth.getGlob());
       assertEquals("Check type 3", RuleType.DENY, fourth.getType());
@@ -181,13 +181,13 @@ public class RuleTest {
 
     List<ILoggingEvent> logsList = listAppender.list;
     assertEquals("Should be 7 log entries", 7, logsList.size());
-    assertTrue(logsList.get(0).getMessage().startsWith("Each rule must begin with a '{' character."));
+    assertTrue(logsList.get(0).getMessage().startsWith("Each filter rule must begin with a '{' character."));
     assertEquals("Severity should be ERROR.", Level.ERROR, logsList.get(0).getLevel());
 
-    assertTrue(logsList.get(1).getMessage().startsWith("Each rule must begin with a '{' character."));
+    assertTrue(logsList.get(1).getMessage().startsWith("Each filter rule must begin with a '{' character."));
     assertEquals("Severity should be ERROR.", Level.ERROR, logsList.get(1).getLevel());
 
-    assertTrue(logsList.get(2).getMessage().startsWith("A reserved token was used to label a Rule indicating a section may have been closed incorrectly.  Label=\"glob\""));
+    assertTrue(logsList.get(2).getMessage().startsWith("A reserved token was used to label a Filter indicating a section may have been closed incorrectly.  Label=\"glob\""));
     assertEquals("Severity should be WARN.", Level.WARN, logsList.get(2).getLevel());
   }
 }

--- a/core/src/test/java/com/adobe/aem/dot/dispatcher/core/model/RuleTest.java
+++ b/core/src/test/java/com/adobe/aem/dot/dispatcher/core/model/RuleTest.java
@@ -52,7 +52,7 @@ public class RuleTest {
   @Before
   public void before() {
     // Get Logback Logger: create and start a ListAppender
-    listAppender = AssertHelper.getLogAppender(Filter.class);
+    listAppender = AssertHelper.getLogAppender(FilterRule.class);
   }
 
   @BeforeClass
@@ -86,13 +86,13 @@ public class RuleTest {
       assertNotEquals("Try the hashcode()", "hello", cache.hashCode());
       // ====================================================================
 
-      List<Filter> rules = cache.getRules().getValue();
+      List<FilterRule> rules = cache.getRules().getValue();
       assertNotNull(rules);
 
       assertEquals("Check filter size", 4, rules.size());
 
       // Check Rule values
-      Filter first = rules.get(0);
+      FilterRule first = rules.get(0);
       assertEquals("Check label 1", "0000", first.getLabel());
       assertEquals("Check glob 1", "*", first.getGlob());
       assertEquals("Check type 1", RuleType.ALLOW, first.getType());
@@ -107,7 +107,7 @@ public class RuleTest {
       assertNotNull("Should be a logger", first.getLogger());
       assertNotNull("Should be a class name", first.getSimpleClassName());
 
-      Filter second = rules.get(1);
+      FilterRule second = rules.get(1);
       assertEquals("Check label 2", "stout", second.getLabel());
       assertEquals("Check glob 2", "/en/news/'*?lang=en", second.getGlob());
       assertEquals("Check type 2", RuleType.DENY, second.getType());
@@ -118,11 +118,11 @@ public class RuleTest {
               second.getLabelData().getIncludedFrom());
       assertEquals("equals itself", second, second);
 
-      Filter third = rules.get(2);
+      FilterRule third = rules.get(2);
       assertNull("Null type", third.getType());
       assertEquals("Equals without type", "Label=notype,Method=get", third.toString());
 
-      Filter fourth = rules.get(3);
+      FilterRule fourth = rules.get(3);
       assertTrue("Check label 3", StringUtils.isEmpty(fourth.getLabel()));
       assertEquals("Check glob 3", "*/private/*", fourth.getGlob());
       assertEquals("Check type 3", RuleType.DENY, fourth.getType());
@@ -187,7 +187,7 @@ public class RuleTest {
     assertTrue(logsList.get(1).getMessage().startsWith("Each filter rule must begin with a '{' character."));
     assertEquals("Severity should be ERROR.", Level.ERROR, logsList.get(1).getLevel());
 
-    assertTrue(logsList.get(2).getMessage().startsWith("A reserved token was used to label a Filter indicating a section may have been closed incorrectly.  Label=\"glob\""));
+    assertTrue(logsList.get(2).getMessage().startsWith("A reserved token was used to label a FilterRule indicating a section may have been closed incorrectly.  Label=\"glob\""));
     assertEquals("Severity should be WARN.", Level.WARN, logsList.get(2).getLevel());
   }
 }

--- a/core/src/test/resources/com/adobe/aem/dot/dispatcher/core/model/cache/cache.any
+++ b/core/src/test/resources/com/adobe/aem/dot/dispatcher/core/model/cache/cache.any
@@ -30,4 +30,16 @@
   /mode "0200"
   /gracePeriod "2"
   /enableTTL "1"
+
+  /rules {
+    /0000  {  /glob "*"   /type "deny" }
+    /0001  {  /glob "*.html" /type "allow" }
+    /0002  {
+      /type "allow"
+      /path "/etc"
+      /selectors '(test-selector)'
+      /extension '(css|js)'
+      /suffix "test-suffix"
+    }
+  }
 }


### PR DESCRIPTION


## Description

A user has reported the following issue that was flagged by the DOT:

```
Skipping unknown /rule level token. Token="/selectors".
```

In their configuration, /selectors was being used from the /cache /rules section, which the official docs [1] would suggest is not permitted:

> Each item in the /rules property includes a glob pattern and a type:
>
> The glob pattern is used to match the path of the document.
> The type indicates whether to cache the documents that match the glob pattern. The value can be either allow (to cache the document) or deny (to always render the document).

However, it turns out that using /selectors, /path, /extension, and /suffix in the cache rules section works just fine. The DOT should be adjusted to match the behaviour of the dispatcher.

[1] https://experienceleague.adobe.com/docs/experience-manager-dispatcher/using/configuring/dispatcher-configuration.html?lang=en#specifying-the-documents-to-cache

## Related Issues

CEL-312
CEL-319

## Motivation and Context

We need to support all the ways the dispatcher is configured in practice.

## How Has This Been Tested?

Updated existing test cases.

## Screenshots (if appropriate):

Before & after:

<img width="1726" alt="Screen Shot 2021-06-29 at 1 15 12 PM" src="https://user-images.githubusercontent.com/1048207/123841049-1795d700-d8dd-11eb-9a16-8f7787abf2bd.png">


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
